### PR TITLE
Add width/height multiplier support, upsidedown text and text smoothing

### DIFF
--- a/doc/user/methods.rst
+++ b/doc/user/methods.rst
@@ -65,8 +65,8 @@ text("text")
 
 Prints raw text. Raises ``TextError`` exception.
 
-set("align", "font", "type", width, height, invert)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+set("align", "font", "type", width, height, invert, smooth, flip)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Set text properties.
 * ``align`` set horizontal position for text, the possible values are:
@@ -80,6 +80,8 @@ Set text properties.
 * ``width`` is a numeric value, 1 is for regular size, and 2 is twice the standard size. *Default*: 1
 * ``height`` is a numeric value, 1 is for regular size and 2 is twice the standard size. *Default*: 1
 * ``invert`` is a boolean value, True enables white on black printing. *Default*: False
+* ``smooth`` is a boolean value, True enables text smoothing. *Default*: False
+* ``flip`` is a boolean value, True enables upside-down text. *Default*: False
 
 cut("mode")
 ^^^^^^^^^^^

--- a/escpos/constants.py
+++ b/escpos/constants.py
@@ -50,6 +50,27 @@ PAPER_PART_CUT = _CUT_PAPER('\x01')  # Partial cut paper
 # Text format
 # TODO: Acquire the "ESC/POS Application Programming Guide for Paper Roll
 #       Printers" and tidy up this stuff too.
+TXT_FLIP_ON    = ESC + '\x7b\x01'
+TXT_FLIP_OFF   = ESC + '\x7b\x00'
+TXT_SMOOTH_ON  = GS + '\x62\x01'
+TXT_SMOOTH_OFF = GS + '\x62\x00'
+TXT_SIZE       = GS + '!'
+TXT_WIDTH      = {1: 0x00,
+                  2: 0x10,
+                  3: 0x20,
+                  4: 0x30,
+                  5: 0x40,
+                  6: 0x50,
+                  7: 0x60,
+                  8: 0x70}
+TXT_HEIGHT     = {1: 0x00,
+                  2: 0x01,
+                  3: 0x02,
+                  4: 0x03,
+                  5: 0x04,
+                  6: 0x05,
+                  7: 0x06,
+                  8: 0x07}
 TXT_NORMAL     = ESC + '!\x00'     # Normal text
 TXT_2HEIGHT    = ESC + '!\x10'     # Double height text
 TXT_2WIDTH     = ESC + '!\x20'     # Double width text

--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -492,17 +492,21 @@ class Escpos(object):
             self._raw(TXT_2WIDTH)
         elif width == 1 and height == 1:
             self._raw(TXT_NORMAL)
-        else:
+        elif width >= 1 and width <= 8 and height >= 1 and height <= 8 and isinstance(width, int) and isinstance(height, int):
             self._raw(TXT_SIZE + chr(TXT_WIDTH[width] + TXT_HEIGHT[height]))
-        # Type
+        else:
+            raise SetVariableError()
+        # Upside down
         if flip == True:
             self._raw(TXT_FLIP_ON)
         else:
             self._raw(TXT_FLIP_OFF)
+        # Smoothing
         if smooth == True:
             self._raw(TXT_SMOOTH_ON)
         else:
             self._raw(TXT_SMOOTH_OFF)
+        # Type
         if text_type.upper() == "B":
             self._raw(TXT_BOLD_ON)
             self._raw(TXT_UNDERL_OFF)

--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -451,7 +451,7 @@ class Escpos(object):
         colCount = self.columns if columns is None else columns
         self.text(textwrap.fill(txt, colCount))
 
-    def set(self, align='left', font='a', text_type='normal', width=1, height=1, density=9, invert=False):
+    def set(self, align='left', font='a', text_type='normal', width=1, height=1, density=9, invert=False, smooth=False, flip=False):
         """ Set text properties by sending them to the printer
 
         :param align: horizontal position for text, possible values are:
@@ -466,32 +466,43 @@ class Escpos(object):
 
             * B for bold
             * U for underlined
-            * B2 for bold, version 2
             * U2 for underlined, version 2
             * BU for bold and underlined
             * BU2 for bold and underlined, version 2
             * NORMAL for normal text
 
             *default*: NORMAL
-        :param width: text width, normal (1) or double width (2), *default*: 1
-        :param height: text height, normal (1) or double height (2), *default*: 1
+        :param width: text width multiplier, decimal range 1-8,  *default*: 1
+        :param height: text height multiplier, decimal range 1-8, *default*: 1
         :param density: print density, value from 0-8, if something else is supplied the density remains unchanged
         :param invert: True enables white on black printing, *default*: False
+        :param smooth: True enables text smoothing. Effective on 4x4 size text and larger, *default*: False
+        :param flip: True enables upside-down printing, *default*: False
         :type invert: bool
         """
         # Width
         if height == 2 and width == 2:
             self._raw(TXT_NORMAL)
             self._raw(TXT_4SQUARE)
-        elif height == 2 and width != 2:
+        elif height == 2 and width == 1:
             self._raw(TXT_NORMAL)
             self._raw(TXT_2HEIGHT)
-        elif width == 2 and height != 2:
+        elif width == 2 and height == 1:
             self._raw(TXT_NORMAL)
             self._raw(TXT_2WIDTH)
-        else:  # DEFAULT SIZE: NORMAL
+        elif width == 1 and height == 1:
             self._raw(TXT_NORMAL)
+        else:
+            self._raw(TXT_SIZE + chr(TXT_WIDTH[width] + TXT_HEIGHT[height]))
         # Type
+        if flip == True:
+            self._raw(TXT_FLIP_ON)
+        else:
+            self._raw(TXT_FLIP_OFF)
+        if smooth == True:
+            self._raw(TXT_SMOOTH_ON)
+        else:
+            self._raw(TXT_SMOOTH_OFF)
         if text_type.upper() == "B":
             self._raw(TXT_BOLD_ON)
             self._raw(TXT_UNDERL_OFF)

--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -492,7 +492,7 @@ class Escpos(object):
             self._raw(TXT_2WIDTH)
         elif width == 1 and height == 1:
             self._raw(TXT_NORMAL)
-        elif width >= 1 and width <= 8 and height >= 1 and height <= 8 and isinstance(width, int) and isinstance(height, int):
+        elif 1 <= width <= 8 and 1 <= height <= 8 and isinstance(width, int) and isinstance(height, int):
             self._raw(TXT_SIZE + chr(TXT_WIDTH[width] + TXT_HEIGHT[height]))
         else:
             raise SetVariableError()

--- a/escpos/exceptions.py
+++ b/escpos/exceptions.py
@@ -12,6 +12,7 @@ Result/Exit codes:
     - `70` = Invalid number of tab positions :py:exc:`~escpos.exceptions.TabPosError`
     - `80` = Invalid char code :py:exc:`~escpos.exceptions.CharCodeError`
     - `90` = USB device not found :py:exc:`~escpos.exceptions.USBNotFoundError`
+    - `100` = Set variable out of range :py:exc:`~escpos.exceptions.SetVariableError`
 
 :author: `Manuel F Martinez <manpaz@bashlinux.com>`_ and others
 :organization: Bashlinux and `python-escpos <https://github.com/python-escpos>`_
@@ -167,3 +168,18 @@ class USBNotFoundError(Error):
 
     def __str__(self):
         return "USB device not found"
+
+
+class SetVariableError(Error):
+    """ A set method variable was out of range
+
+    Check set variables against minimum and maximum values
+    Ths returncode for this exception is `100`.
+    """
+    def __init__(self, msg=""):
+        Error.__init__(self, msg)
+        self.msg = msg
+        self.resultcode = 100
+
+    def __str__(self):
+        return "Set variable out of range"


### PR DESCRIPTION
Alright worked a bit on adding some text features.

Firstly upside-down text. Simple enough.
Text smoothing. Effective on text stretched to 4x height or width.

Width/Height.
Escpos has a GS ! command similar to the ESC ! that was currently in use for text size
The GS ! command supports up to 8x scaling of the width and/or height of fonts. 
I do not know what printer support is like for the GS ! vs Esc ! command.
So if the width/height is set to 1 or 2 or combination thereof we use the old method of ESC ! but if height/width > 2 then we use the GS ! method. This maintains full backwards compatibility, sending the same commands down the wire for existing users.

I also fixed a typo in constants.py
There was a comment in the set method that it supported a "B2" text style. 
There is no second bold style I could find supported by the escpos command set.
I removed this line. 

Cheers