### PR TITLE
Clean up non-float value, add v3.5 to tox test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: python
 sudo: false
 cache: pip
+matrix:
+  include:
+  - python: 2.7
+    env: TOXENV=py27
+  - python: 3.4
+    env: TOXENV=py34
+  - python: 3.5
+    env: TOXENV=py35
 before_install:
     - pip install tox
 # command to run tests

--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -83,7 +83,7 @@ class Escpos(object):
         pbuffer = b''
 
         self._raw(S_RASTER_N)
-        pbuffer = "%02X%02X%02X%02X" % (((size[0]/size[1])/8), 0, size[1] & 0xff, size[1] >> 8)
+        pbuffer = "%02X%02X%02X%02X" % (((size[0]//size[1])//8), 0, size[1] & 0xff, size[1] >> 8)
         self._raw(binascii.unhexlify(pbuffer))
         pbuffer = ""
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py27, py34, py35
 
 [testenv]
 deps = nose


### PR DESCRIPTION
One of the divisions should be returning an integer rather than a float. This change adjusts a division operator and adds python 3.5 to the tox.ini file.

Note that the discussion on #107 refers to the same problem, and that test failures in #110 log this line as the culprit, as the `.format()` syntax it uses picks up on the float value.

    pbuffer = "{0:02X}{1:02X}{2:02X}{3:02X}".format(((size[0]/size[1])/8), 0, size[1] & 0xff, size[1] >> 8)
    nose.proxy.ValueError: Unknown format code 'X' for object of type 'float'

Tested by printing the test images after the change, to an Epson TM-T20II.