### PR TITLE
Implement ESC/POS QR code rendering

### DIFF
--- a/escpos/constants.py
+++ b/escpos/constants.py
@@ -183,6 +183,16 @@ BARCODE_TYPES = {
     'B': BARCODE_TYPE_B,
 }
 
+## QRCode error correction levels
+QR_ECLEVEL_L = 0;
+QR_ECLEVEL_M = 1;
+QR_ECLEVEL_Q = 2;
+QR_ECLEVEL_H = 3;
+    
+## QRcode models
+QR_MODEL_1 = 1;
+QR_MODEL_2 = 2;
+QR_MICRO = 3;
 
 # Image format
 # NOTE: _PRINT_RASTER_IMG is the obsolete ESC/POS "print raster bit image"

--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -299,10 +299,10 @@ class Escpos(object):
         # Set error correction level: L, M, Q, or H
         self._send_2d_code_data(six.int2byte(69), cn, six.int2byte(48 + ec));
         # Send content & print
-        self._send_2d_code_data(six.int2byte(80), cn, content, b'0');
+        self._send_2d_code_data(six.int2byte(80), cn, content.encode('utf-8'), b'0');
         self._send_2d_code_data(six.int2byte(81), cn, b'', b'0');
 
-    def _send_2d_code_data(self, fn, cn, data, m=''):
+    def _send_2d_code_data(self, fn, cn, data, m=b''):
         """ Wrapper for GS ( k, to calculate and send correct data length.
 
         :param fn: Function to use.

--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -257,17 +257,18 @@ class Escpos(object):
         """ Print QR Code for the provided string
 
         :param content: The content of the code. Numeric data will be more efficiently compacted.
-        :param ec: Error-correction level to use. One of QR_ECLEVEL_L (default), QR_ECLEVEL_M, QR_ECLEVEL_Q or QR_ECLEVEL_H. Higher error correction results in a less compact code.
+        :param ec: Error-correction level to use. One of QR_ECLEVEL_L (default), QR_ECLEVEL_M, QR_ECLEVEL_Q or QR_ECLEVEL_H.
+            Higher error correction results in a less compact code.
         :param size: Pixel size to use. Must be 1-16 (default 3)
         :param model: QR code model to use. Must be one of QR_MODEL_1, QR_MODEL_2 (default) or QR_MICRO (not supported by all printers).
         :param native: True to render the code on the printer, False to render the code as an image and send it to the printer (Default)
         """
         # Basic validation
-        if not ec in [QR_ECLEVEL_L, QR_ECLEVEL_M, QR_ECLEVEL_H, QR_ECLEVEL_Q]:
+        if ec not in [QR_ECLEVEL_L, QR_ECLEVEL_M, QR_ECLEVEL_H, QR_ECLEVEL_Q]:
             raise ValueError("Invalid error correction level")
         if not 1 <= size <= 16:
             raise ValueError("Invalid block size (must be 1-16)")
-        if not model in [QR_MODEL_1, QR_MODEL_2, QR_MICRO]:
+        if model not in [QR_MODEL_1, QR_MODEL_2, QR_MICRO]:
             raise ValueError("Invalid QR model (must be one of QR_MODEL_1, QR_MODEL_2, QR_MICRO)")
         if content == "":
             # Handle edge case by printing nothing.

--- a/test/test_function_qr_native.py
+++ b/test/test_function_qr_native.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+"""tests for panel button function
+
+:author: `Patrick Kanzler <patrick.kanzler@fablab.fau.de>`_
+:organization: `python-escpos <https://github.com/python-escpos>`_
+:copyright: Copyright (c) 2016 `python-escpos <https://github.com/python-escpos>`_
+:license: GNU GPL v3
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nose.tools import with_setup
+
+import escpos.printer as printer
+import os
+from escpos.constants import QR_ECLEVEL_H, QR_MODEL_1
+
+devfile = 'testfile'
+
+
+def setup_testfile():
+    """create a testfile as devfile"""
+    fhandle = open(devfile, 'a')
+    try:
+        os.utime(devfile, None)
+    finally:
+        fhandle.close()
+
+
+def teardown_testfile():
+    """destroy testfile again"""
+    os.remove(devfile)
+
+
+@with_setup(setup_testfile, teardown_testfile)
+def test_function_qr_defaults():
+    """test QR code with defaults"""
+    instance = printer.File(devfile=devfile)
+    instance.qr("1234", native=True)
+    instance.flush()
+    with open(devfile, "rb") as f:
+        assert(f.read() == b'\x1d(k\x04\x001A2\x00\x1d(k\x03\x001C\x03\x1d(k\x03\x001E0\x1d(k\x07\x001P01234\x1d(k\x03\x001Q0')
+
+@with_setup(setup_testfile, teardown_testfile)
+def test_function_qr_empty():
+    """test QR printing blank code"""
+    instance = printer.File(devfile=devfile)
+    instance.qr("", native=True)
+    instance.flush()
+    with open(devfile, "rb") as f:
+        assert(f.read() == b'')
+
+@with_setup(setup_testfile, teardown_testfile)
+def test_function_qr_ec():
+    """test QR error correction setting"""
+    instance = printer.File(devfile=devfile)
+    instance.qr("1234", native=True, ec=QR_ECLEVEL_H)
+    instance.flush()
+    with open(devfile, "rb") as f:
+        assert(f.read() == b'\x1d(k\x04\x001A2\x00\x1d(k\x03\x001C\x03\x1d(k\x03\x001E3\x1d(k\x07\x001P01234\x1d(k\x03\x001Q0')
+
+@with_setup(setup_testfile, teardown_testfile)
+def test_function_qr_size():
+    """test QR box size"""
+    instance = printer.File(devfile=devfile)
+    instance.qr("1234", native=True, size=7)
+    instance.flush()
+    with open(devfile, "rb") as f:
+        assert(f.read() == b'\x1d(k\x04\x001A2\x00\x1d(k\x03\x001C\x07\x1d(k\x03\x001E0\x1d(k\x07\x001P01234\x1d(k\x03\x001Q0')
+
+@with_setup(setup_testfile, teardown_testfile)
+def test_function_qr_model():
+    """test QR model"""
+    instance = printer.File(devfile=devfile)
+    instance.qr("1234", native=True, model=QR_MODEL_1)
+    instance.flush()
+    with open(devfile, "rb") as f:
+        assert(f.read() == b'\x1d(k\x04\x001A1\x00\x1d(k\x03\x001C\x03\x1d(k\x03\x001E0\x1d(k\x07\x001P01234\x1d(k\x03\x001Q0')


### PR DESCRIPTION
This pull request implements the ESC/POS command for QR code rendering: `GS ( k`. The added code is a direct port of the same feature in in [mike42/escpos-php](https://github.com/mike42/escpos-php) (see [Printer.php](https://github.com/mike42/escpos-php/blob/550d7bc5b5c6c81cea42099bc51a0fbf7c797b87/src/Mike42/Escpos/Printer.php), [EscposTest.php](https://github.com/mike42/escpos-php/blob/550d7bc5b5c6c81cea42099bc51a0fbf7c797b87/test/unit/EscposTest.php), mike42/escpos-php#19). As in the original code, the error correction level, code model and block size are now user-selectable, and test cases have also been ported. This was tested on an Epson TM-T20II.

On printers that don't support the command, existing code wont break, but some new (optional) parameters are now added-

```python
epson.qr("http://www.example.com/", size=10)
```

```
$ time python -m escpos.cli test

real	0m1.852s
user	0m1.056s
sys	0m0.700s
```

But on printers with `GS ( k`, the QR code can be rendered on the printer instead. The `escpos.qr` method simply needs `native=True` to render the same output on the printer:

```python
epson.qr("http://www.example.com/", native=True, size=10)
```

```
$ time python -m escpos.cli test

real	0m0.073s
user	0m0.052s
sys	0m0.008s
```

Because image processing is not used, the second example executed some 25x faster, probably fixing #22.

--

Notes-
- I've locally had to adjust `cli.py` to print a newline: `epson.text("Scan to recall TODO list\n")`, so that the printer's print buffer is empty before image commands arrive. I'm not including this in the pull request to avoid conflicting with #107
- Feedback on code style/quality and/or adherence to project conventions would be appreciated, as I'll be porting some more substantial code in the next few weeks.