### PR TITLE
improve travis configuration with more versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,26 @@ sudo: false
 cache: pip
 matrix:
   include:
-  - python: 2.7
-    env: TOXENV=py27
-  - python: 3.4
-    env: TOXENV=py34
-  - python: 3.5
-    env: TOXENV=py35
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.5-dev
+      env: TOXENV=py35
+    - python: nightly
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
+  allow_failures:
+    - python: pypy3
+    - python: 3.5-dev
+    - python: nightly
 before_install:
     - pip install tox codecov
 script:


### PR DESCRIPTION
Testing compatibility: add python 3.3, pypy, pypy3, 3.5-dev, 3.6-nightly to .travis.yml
allow failure on pypy3, 3.5-dev and nightly

@mike42: I just found the rest off your branch and liked it. I have rebased it to current development HEAD. I hope that's OK for you.