### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -41,13 +41,13 @@ class Escpos:
         buffer = ""
        
         self._raw(S_RASTER_N)
-        buffer = "%02X%02X%02X%02X" % (((size[0]/size[1])/8), 0, size[1]&0xff, size[1]>>8)
+        buffer = "{0:02X}{1:02X}{2:02X}{3:02X}".format(((size[0]/size[1])/8), 0, size[1]&0xff, size[1]>>8)
         self._raw(buffer.decode('hex'))
         buffer = ""
 
         while i < len(line):
             hex_string = int(line[i:i+8],2)
-            buffer += "%02X" % hex_string
+            buffer += "{0:02X}".format(hex_string)
             i += 8
             cont += 1
             if cont % 4 == 0:
@@ -91,7 +91,7 @@ class Escpos:
                 for x in range(pattern_len):
                     if im_color <= (255 * 3 / pattern_len * (x+1)):
                         if im_pattern[x] == "X":
-                            pix_line += "%d" % switch
+                            pix_line += "{0:d}".format(switch)
                         else:
                             pix_line += im_pattern[x]
                         break

--- a/escpos/printer.py
+++ b/escpos/printer.py
@@ -52,13 +52,13 @@ class Usb(Escpos):
                 self.device.detach_kernel_driver(0)
             except usb.core.USBError as e:
                 if check_driver is not None:
-                    print "Could not detatch kernel driver: %s" % str(e)
+                    print "Could not detatch kernel driver: {0!s}".format(str(e))
 
         try:
             self.device.set_configuration()
             self.device.reset()
         except usb.core.USBError as e:
-            print "Could not set configuration: %s" % str(e)
+            print "Could not set configuration: {0!s}".format(str(e))
 
 
     def _raw(self, msg):
@@ -114,7 +114,7 @@ class Serial(Escpos):
         if self.device is not None:
             print "Serial printer enabled"
         else:
-            print "Unable to open serial printer on: %s" % self.devfile
+            print "Unable to open serial printer on: {0!s}".format(self.devfile)
 
 
     def _raw(self, msg):
@@ -148,7 +148,7 @@ class Network(Escpos):
         self.device.connect((self.host, self.port))
 
         if self.device is None:
-            print "Could not open socket for %s" % self.host
+            print "Could not open socket for {0!s}".format(self.host)
 
 
     def _raw(self, msg):
@@ -178,7 +178,7 @@ class File(Escpos):
         self.device = open(self.devfile, "wb")
 
         if self.device is None:
-            print "Could not open the specified file %s" % self.devfile
+            print "Could not open the specified file {0!s}".format(self.devfile)
 
 
     def _raw(self, msg):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:python-escpos:python-escpos?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:python-escpos:python-escpos?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)