### PR TITLE
FIX abstractbaseclass in Escpos not properly loaded

### DIFF
--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -29,13 +29,13 @@ from .exceptions import *
 from abc import ABCMeta, abstractmethod  # abstract base class support
 
 
+@six.add_metaclass(ABCMeta)
 class Escpos(object):
     """ ESC/POS Printer object
 
     This class is the abstract base class for an esc/pos-printer. The printer implementations are children of this
     class.
     """
-    __metaclass__ = ABCMeta
     device = None
 
     def __init__(self, columns=32):

--- a/test/test_abstract_base_class.py
+++ b/test/test_abstract_base_class.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+"""verifies that the metaclass abc is properly used by Escpos
+
+:author: `Patrick Kanzler <patrick.kanzler@fablab.fau.de>`_
+:organization: `python-escpos <https://github.com/python-escpos>`_
+:copyright: Copyright (c) 2016 Patrick Kanzler
+:license: GNU GPL v3
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nose.tools import raises
+
+import escpos.escpos as escpos
+from abc import ABCMeta
+
+
+@raises(TypeError)
+def test_abstract_base_class_raises():
+    """test whether the abstract base class raises an exception for Escpos"""
+    escpos.Escpos()  # This call should raise TypeError because of abstractmethod _raw()
+
+
+def test_abstract_base_class():
+    """ test whether Escpos has the metaclass ABCMeta """
+    assert issubclass(escpos.Escpos, object)
+    assert type(escpos.Escpos) is ABCMeta


### PR DESCRIPTION
* fixes #126
* adds a test to verify the patch
* uses a helperfunction of six in order to properly load ABCMeta in Python 2 and 3