### PR TITLE
Change the interface param to timeout

### DIFF
--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -34,18 +34,18 @@ class Usb(Escpos):
 
     """
 
-    def __init__(self, idVendor, idProduct, interface=0, in_ep=0x82, out_ep=0x01, *args, **kwargs):
+    def __init__(self, idVendor, idProduct, timeout=0, in_ep=0x82, out_ep=0x01, *args, **kwargs):
         """
         :param idVendor: Vendor ID
         :param idProduct: Product ID
-        :param interface: USB device interface
+        :param timeout: Is the time limit of the USB operation. Default without timeout.
         :param in_ep: Input end point
         :param out_ep: Output end point
         """
         Escpos.__init__(self, *args, **kwargs)
         self.idVendor = idVendor
         self.idProduct = idProduct
-        self.interface = interface
+        self.timeout = timeout
         self.in_ep = in_ep
         self.out_ep = out_ep
         self.open()
@@ -82,7 +82,7 @@ class Usb(Escpos):
         :param msg: arbitrary code to be printed
         :type msg: bytes
         """
-        self.device.write(self.out_ep, msg, self.interface)
+        self.device.write(self.out_ep, msg, self.timeout)
 
     def close(self):
         """ Release USB interface """


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [X] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
 * [X] Epson TM-T120
- [X] My contribution is ready to be merged as is

----------

### Description
The parameter named `interface` in init of class `printer.Usb` is being used to pass the timeout for the usb device. I just rename this parameter to timeout and adjusted the documentation.