### PR TITLE
fix printing of CODE128

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,7 @@ Content
    user/raspi
    user/todo
    user/usage
+   user/barcode
 
 .. toctree::
    :maxdepth: 1

--- a/doc/user/barcode.rst
+++ b/doc/user/barcode.rst
@@ -1,0 +1,34 @@
+Printing Barcodes
+-----------------
+:Last Reviewed: 2016-07-31
+
+Most ESC/POS-printers implement barcode-printing.
+The barcode-commandset is implemented in the barcode-method.
+For a list of compatible barcodes you should check the manual of your printer.
+As a rule of thumb: even older Epson-models support most 1D-barcodes.
+To be sure just try some implementations and have a look at the notices below.
+
+barcode-method
+~~~~~~~~~~~~~~
+The barcode-method is rather low-level and orients itself on the implementation of ESC/POS.
+In the future this class could be supplemented by a high-level class that helps the user generating the payload.
+
+.. py:currentmodule:: escpos.escpos
+
+.. automethod:: Escpos.barcode
+    :noindex:
+
+CODE128
+~~~~~~~
+Code128 barcodes need a certain format.
+For now the user has to make sure that the payload is correct.
+For alphanumeric CODE128 you have to preface your payload with `{B`.
+
+.. code-block:: Python
+
+   from escpos.printer import Dummy, Serial
+   p = Serial()
+   # print CODE128 012ABCDabcd
+   p.barcode("{B012ABCDabcd", "CODE128", function_type="B")
+
+A very good description on CODE128 is also on `Wikipedia <https://en.wikipedia.org/wiki/Code_128>`_.

--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -168,10 +168,7 @@ BARCODE_TYPE_B = {
     'NW7':                         _SET_BARCODE_TYPE(71),
     'CODABAR':                     _SET_BARCODE_TYPE(71),  # Same as NW7
     'CODE93':                      _SET_BARCODE_TYPE(72),
-    # These are all the same barcode, but using different charcter sets
-    'CODE128A':                    _SET_BARCODE_TYPE(73) + b'{A',  # CODE128 character set A
-    'CODE128B':                    _SET_BARCODE_TYPE(73) + b'{B',  # CODE128 character set B
-    'CODE128C':                    _SET_BARCODE_TYPE(73) + b'{C',  # CODE128 character set C
+    'CODE128':                     _SET_BARCODE_TYPE(73),
     'GS1-128':                     _SET_BARCODE_TYPE(74),
     'GS1 DATABAR OMNIDIRECTIONAL': _SET_BARCODE_TYPE(75),
     'GS1 DATABAR TRUNCATED':       _SET_BARCODE_TYPE(76),


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * Epson TM-T88II
- [x] My contribution is ready to be merged as is

----------

### Description

The control sequence {A or {B or {C can't be part of the qr code.
For this the user has to supply this sequence.
(Before CODE128 did not work at all.)