### PR TITLE
Support multiple tab positions

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -617,7 +617,7 @@ class Escpos(object):
         else:  # DEFAULT: DOES NOTHING
             pass
 
-    def control(self, ctl, pos=4):
+    def control(self, ctl, pos=None):
         """ Feed control sequences
 
         :param ctl: string for the following control sequences:
@@ -628,14 +628,16 @@ class Escpos(object):
             * HT *for Horizontal Tab*
             * VT *for Vertical Tab*
 
-        :param pos: integer between 1 and 16, controls the horizontal tab position
+        :param pos: controls the horizontal tab positions. an integer
+           or an iterable of integers.
         :raises: :py:exc:`~escpos.exceptions.TabPosError`
         """
         # Set tab positions
-        if not (1 <= pos <= 16):
-            raise TabPosError()
-        else:
-            self._raw(CTL_SET_HT + six.int2byte(pos))
+        if pos:
+            if not isinstance(pos, (list, tuple)):
+                pos = (pos,)
+            self._raw(CTL_SET_HT + b"".join(map(lambda p: six.int2byte(p), pos)))
+        
         # Set position
         if ctl.upper() == "LF":
             self._raw(CTL_LF)


### PR DESCRIPTION
### Contributor checklist

<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
  - e.g. Epson T88IIIP
- [ ] My contribution is ready to be merged as is

---
### Description

I had some trouble understanding how tabs are supposed to work. I'm a ESCPOS newb; that said, here are some changes that make sense to me:
- My T88IIIP that I am working with certainly supports multiple tab positions.
- They are not limited to 16 either.
- It seems unnecessary that for every control(), we generate a command to initialize the tab positions. Now the tab position needs to be explicitly initialized by calling control() with the pos argument. This is a backwards-incompatibility issue.

There may still be some Py3/Py2 issues here, but I wanted to get an opinion first.
