### PR TITLE
Corrected set() command documentation

### DIFF
--- a/doc/user/methods.rst
+++ b/doc/user/methods.rst
@@ -84,7 +84,7 @@ text("text")
 
 Prints raw text. Raises ``TextError`` exception.
 
-set("align", "font", "type", width, height, invert, smooth, flip)
+set("align", "font", "text_type", width, height, invert, smooth, flip)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Set text properties.
@@ -96,7 +96,7 @@ Set text properties.
   * RIGHT > > *Default:* left
    
 * ``font`` type could be ``A`` or ``B``. *Default:* A
-* ``type`` type could be ``B`` (Bold), ``U`` (Underline) or ``normal``. *Default:* normal
+* ``text_type`` type could be ``B`` (Bold), ``U`` (Underline) or ``normal``. *Default:* normal
 * ``width`` is a numeric value, 1 is for regular size, and 2 is twice the standard size. *Default*: 1
 * ``height`` is a numeric value, 1 is for regular size and 2 is twice the standard size. *Default*: 1
 * ``invert`` is a boolean value, True enables white on black printing. *Default*: False

--- a/doc/user/methods.rst
+++ b/doc/user/methods.rst
@@ -85,7 +85,7 @@ text("text")
 Prints raw text. Raises ``TextError`` exception.
 
 set("align", "font", "text_type", width, height, invert, smooth, flip)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Set text properties.
 


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [ ] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
**n.a - no actual code has been changed**
- [x] My contribution is ready to be merged as is

----------

### Description

The documentation currently says that `printer.set(type="B")` is the way to bold text. It won't work - you need to use `printer.set(text_type="B")`. I've corrected the docs as such.