### PR TITLE
Update printer DB submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "capabilities-data"]
 	path = capabilities-data
-	url = https://github.com/mike42/escpos-printer-db.git
+	url = https://github.com/receipt-print-hq/escpos-printer-db.git


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [ ] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
- [x] My contribution is ready to be merged as is

----------

### Description

This pull request updates the submodule path for escpos-printer-db, to reflect its transfer to an 'organsation' account.

References:
- #174
- receipt-print-hq/escpos-printer-db#12
