### PR TITLE
Add support for custom cash drawer kick sequence

### DIFF
--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -47,6 +47,7 @@ HW_RESET  = ESC + b'\x3f\x0a\x00'   # Reset printer hardware
 
 # Cash Drawer (ESC p <pin> <on time: 2*ms> <off time: 2*ms>)
 _CASH_DRAWER = lambda m, t1='', t2='': ESC + b'p' + m + six.int2byte(t1) + six.int2byte(t2)
+CD_KICK_DEC_SEQUENCE = lambda esc, p, m, t1=50, t2=50: six.int2byte(esc) + six.int2byte(p) + six.int2byte(m) + six.int2byte(t1) + six.int2byte(t2)
 CD_KICK_2 = _CASH_DRAWER(b'\x00', 50, 50)  # Sends a pulse to pin 2 []
 CD_KICK_5 = _CASH_DRAWER(b'\x01', 50, 50)  # Sends a pulse to pin 5 []
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -636,9 +636,10 @@ class Escpos(object):
     def cashdraw(self, pin):
         """ Send pulse to kick the cash drawer
 
-        Kick cash drawer on pin 2 or pin 5 according to parameter.
+        Kick cash drawer on pin 2 or pin 5 according to default parameter.
+        For non default parameter send a decimal sequence i.e. [27,112,48] or [27,112,0,25,255]
 
-        :param pin: pin number, 2 or 5
+        :param pin: pin number, 2 or 5 or list of decimals
         :raises: :py:exc:`~escpos.exceptions.CashDrawerError`
         """
         if pin == 2:
@@ -646,7 +647,10 @@ class Escpos(object):
         elif pin == 5:
             self._raw(CD_KICK_5)
         else:
-            raise CashDrawerError()
+            try:
+                self._raw(CD_KICK_DEC_SEQUENCE(*pin))
+            except:
+                raise CashDrawerError()
 
     def hw(self, hw):
         """ Hardware operations


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [ ] I have tested my contribution on these devices:
 *Epson TM-H6000
 *Epson TM-U210
- [x] My contribution is ready to be merged as is

----------

### Description
Seems that some printers need a different pulse sequence than default to kick the cash drawer:
http://keyhut.com/popopen.htm
This PR adds support for method cashdraw() to accept a decimal list of escapes that contains the cash drawer kick sequence.
Is backwards compatible and maybe useful in a future for the capabilities feature.