### PR TITLE
Swap default image fragment height to 960

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -59,7 +59,7 @@ class Escpos(object):
         pass
 
     def image(self, img_source, high_density_vertical=True, high_density_horizontal=True, impl="bitImageRaster",
-              fragment_height=1024):
+              fragment_height=960):
         """ Print an image
 
         You can select whether the printer should print in high density or not. The default value is high density.


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [ ] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
- [x] My contribution is ready to be merged as is

----------

The image formats in ESC/POS handle (variously) rows of 1, 8 or 24 rows of pixels at a time. The default image fragment height is currently 1024. Some image formats used in ESC/POS are not capable of representing this size without padding the image (eg, high density column-format bit images).

This pull request changes the default fragment height to 960, which is a multiple of 24, so that vertical white-space is not sent to the printer for long images.
