### PR TITLE
change dependency to docutils to newer version of sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - python: nightly
     - python: pypy3
 before_install:
-    - pip install tox codecov docutils==0.12
+    - pip install tox codecov 'sphinx>=1.5.1'
 script:
     - tox
     - codecov

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,4 +4,4 @@ qrcode>=4.0
 pyserial
 sphinx-rtd-theme
 setuptools-scm
-docutils==0.12
+docutils>=0.12

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ commands = py.test --cov escpos
 [testenv:docs]
 basepython = python
 changedir = doc
-deps = sphinx
+deps = sphinx>=1.5.1
        setuptools_scm
-       docutils==0.12
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
This is a revert to f8b7238801c82f7858c64a60162cbe36aa8fe332

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] My contribution is ready to be merged as is

----------

### Description
This should be better than requiring docutils