### PR TITLE
Correct fragment_height documentation default

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -79,7 +79,7 @@ class Escpos(object):
         :param high_density_vertical: print in high density in vertical direction *default:* True
         :param high_density_horizontal: print in high density in horizontal direction *default:* True
         :param impl: choose image printing mode between `bitImageRaster`, `graphics` or `bitImageColumn`
-        :param fragment_height: Images larger than this will be split into multiple fragments *default:* 1024
+        :param fragment_height: Images larger than this will be split into multiple fragments *default:* 960
 
         """       
         im = EscposImage(img_source)


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [ x] I have read the CONTRIBUTING.rst
- [ x] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
- [x] My contribution is ready to be merged as is

----------

