### PR TITLE
Handle cases when fullCut or partCut not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ src/escpos/version.py
 
 # testing temporary directories
 test/test-cli-output/
+
+# vim swap files
+*.swp
+*.swn
+*.swo

--- a/src/escpos/cli.py
+++ b/src/escpos/cli.py
@@ -100,6 +100,12 @@ ESCPOS_COMMANDS = [
                 'option_strings': ('--content',),
                 'help': 'Text to print as a qr code',
                 'required': True,
+            },
+            {
+                'option_strings': ('--size',),
+                'help': 'QR code size (1-16) [default:3]',
+                'required': False,
+                'type': int,
             }
         ],
     },

--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -53,8 +53,8 @@ CD_KICK_5 = _CASH_DRAWER(b'\x01', 50, 50)  # Sends a pulse to pin 5 []
 
 # Paper Cutter
 _CUT_PAPER = lambda m: GS + b'V' + m
-PAPER_FULL_CUT = _CUT_PAPER(b'\x00')  # Full cut paper
-PAPER_PART_CUT = _CUT_PAPER(b'\x01')  # Partial cut paper
+PAPER_FULL_CUT = _CUT_PAPER(b'\x00\x30')  # Full cut paper
+PAPER_PART_CUT = _CUT_PAPER(b'\x01\x31')  # Partial cut paper
 
 # Beep
 BEEP = b'\x07'

--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -53,8 +53,8 @@ CD_KICK_5 = _CASH_DRAWER(b'\x01', 50, 50)  # Sends a pulse to pin 5 []
 
 # Paper Cutter
 _CUT_PAPER = lambda m: GS + b'V' + m
-PAPER_FULL_CUT = _CUT_PAPER(b'\x00\x30')  # Full cut paper
-PAPER_PART_CUT = _CUT_PAPER(b'\x01\x31')  # Partial cut paper
+PAPER_FULL_CUT = _CUT_PAPER(b'\x00')  # Full cut paper
+PAPER_PART_CUT = _CUT_PAPER(b'\x01')  # Partial cut paper
 
 # Beep
 BEEP = b'\x07'

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -564,7 +564,7 @@ class Escpos(object):
 
         self._raw(LINESPACING_FUNCS[divisor] + six.int2byte(spacing))
 
-    def cut(self, mode=''):
+    def cut(self, mode='FULL'):
         """ Cut paper.
 
         Without any arguments the paper will be cut completely. With 'mode=PART' a partial cut will
@@ -573,17 +573,25 @@ class Escpos(object):
 
         .. todo:: Check this function on TM-T88II.
 
-        :param mode: set to 'PART' for a partial cut
+        :param mode: set to 'PART' for a partial cut. default: 'FULL'
+        :raises ValueError: if mode not in ('FULL', 'PART')
         """
-        # Fix the size between last line and cut
-        # TODO: handle this with a line feed
-        self._raw(b"\n\n\n\n\n\n")
+        self.print_and_feed(6)
 
-        if mode.upper() == "PART" and self.profile.supports('paperPartCut'):
-            self._raw(PAPER_PART_CUT)
-        elif mode.upper() != "PART" and self.profile.supports('paperFullCut'):
-            # DEFAULT MODE: FULL CUT
-            self._raw(PAPER_FULL_CUT)
+        mode = mode.upper()
+        if mode not in ('FULL', 'PART'):
+            raise ValueError("Mode must be one of ('FULL', 'PART')")
+
+        if mode == "PART":
+            if self.profile.supports('paperPartCut'):
+                self._raw(PAPER_PART_CUT)
+            elif self.profile.supports('paperFullCut'):
+                self._raw(PAPER_FULL_CUT)
+        elif mode == "FULL":
+            if self.profile.supports('paperFullCut'):
+                self._raw(PAPER_FULL_CUT)
+            elif self.profile.supports('paperPartCut'):
+                self._raw(PAPER_PART_CUT)
 
     def cashdraw(self, pin):
         """ Send pulse to kick the cash drawer
@@ -621,6 +629,20 @@ class Escpos(object):
             self._raw(HW_RESET)
         else:  # DEFAULT: DOES NOTHING
             pass
+
+    def print_and_feed(self, n):
+        """ Print data in print buffer and feed *n* lines
+
+            if n not in range (0, 255) then ValueError will be raised
+
+            :param n: number of lines to feed. 0 <= n <= 255
+            :raises ValueError: if not 0 <= n <= 255
+        """
+        if 0 <= n <= 255:
+            # ESC d n
+            self._raw(ESC + b"d" + six.binary_type(chr(n)))
+        else:
+            raise ValueError("n must be betwen 0 and 255")
 
     def control(self, ctl, pos=4):
         """ Feed control sequences

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -640,7 +640,7 @@ class Escpos(object):
         """
         if 0 <= n <= 255:
             # ESC d n
-            self._raw(ESC + b"d" + six.binary_type(chr(n)))
+            self._raw(ESC + b"d" + six.int2byte(n))
         else:
             raise ValueError("n must be betwen 0 and 255")
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -630,12 +630,12 @@ class Escpos(object):
         else:  # DEFAULT: DOES NOTHING
             pass
 
-    def print_and_feed(self, n):
+    def print_and_feed(self, n=1):
         """ Print data in print buffer and feed *n* lines
 
             if n not in range (0, 255) then ValueError will be raised
 
-            :param n: number of lines to feed. 0 <= n <= 255
+            :param n: number of n to feed. 0 <= n <= 255. default: 1
             :raises ValueError: if not 0 <= n <= 255
         """
         if 0 <= n <= 255:
@@ -658,11 +658,6 @@ class Escpos(object):
         :param pos: integer between 1 and 16, controls the horizontal tab position
         :raises: :py:exc:`~escpos.exceptions.TabPosError`
         """
-        # Set tab positions
-        if not (1 <= pos <= 16):
-            raise TabPosError()
-        else:
-            self._raw(CTL_SET_HT + six.int2byte(pos))
         # Set position
         if ctl.upper() == "LF":
             self._raw(CTL_LF)
@@ -671,6 +666,12 @@ class Escpos(object):
         elif ctl.upper() == "CR":
             self._raw(CTL_CR)
         elif ctl.upper() == "HT":
+            if not (1 <= pos <= 16):
+                raise TabPosError()
+            else:
+                # Set tab positions
+                self._raw(CTL_SET_HT + six.int2byte(pos))
+
             self._raw(CTL_HT)
         elif ctl.upper() == "VT":
             self._raw(CTL_VT)

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -578,9 +578,11 @@ class Escpos(object):
         # Fix the size between last line and cut
         # TODO: handle this with a line feed
         self._raw(b"\n\n\n\n\n\n")
-        if mode.upper() == "PART":
+
+        if mode.upper() == "PART" and self.profile.supports('paperPartCut'):
             self._raw(PAPER_PART_CUT)
-        else:  # DEFAULT MODE: FULL CUT
+        elif mode.upper() != "PART" and self.profile.supports('paperFullCut'):
+            # DEFAULT MODE: FULL CUT
             self._raw(PAPER_FULL_CUT)
 
     def cashdraw(self, pin):


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * e.g. NETUM NT-5890K
- [ ] My contribution is ready to be merged as is

----------

### Description

Related [PR](https://github.com/receipt-print-hq/escpos-printer-db/pull/25) introduces new features:
- paperPartCut
- paperFullCut

This PR handles them with minimal code changes.