### PR TITLE
Add support for an ESCPOS_CAPABILITIES_FILE environment variable

### DIFF
--- a/src/escpos/capabilities.py
+++ b/src/escpos/capabilities.py
@@ -1,10 +1,15 @@
 import re
 import six
-from os import path
+from os import environ, path
 import yaml
 
 # Load external printer database
-with open(path.join(path.dirname(__file__), 'capabilities.json')) as f:
+if 'ESCPOS_CAPABILITIES_FILE' in environ:
+    file_path = environ['ESCPOS_CAPABILITIES_FILE']
+else:
+    file_path = path.join(path.dirname(__file__), 'capabilities.json')
+
+with open(file_path) as f:
     CAPABILITIES = yaml.load(f)
 
 PROFILES = CAPABILITIES['profiles']


### PR DESCRIPTION
This is useful in situations where package structure is changed, such as using cx-freeze

### Contributor checklist
<!-- mark with x between the brackets -->
- [X] I have read the CONTRIBUTING.rst
- [X] I have tested my contribution on these devices:
 * Epson TM-T20II
- [X] My contribution is ready to be merged as is

----------

### Description
