### PR TITLE
Fixed bad format of :code: in documentation

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -414,7 +414,7 @@ class Escpos(object):
         Text has to be encoded in unicode.
 
         :param txt: text to be printed
-        :param font: font to be used, can be :code:`a` or :code`b`
+        :param font: font to be used, can be :code:`a` or :code:`b`
         :param columns: amount of columns
         :return: None
         """


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
- [x] My contribution is ready to be merged as is

----------

### Description

Fixed a small typo in the documentation that renders weird on ReadTheDocs.