### PR TITLE
Preliminary support of pos 'line display' printing through Epson printer

### DIFF
--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -64,6 +64,11 @@ _PANEL_BUTTON = lambda n: ESC + b'c5' + six.int2byte(n)
 PANEL_BUTTON_ON = _PANEL_BUTTON(0)  # enable all panel buttons
 PANEL_BUTTON_OFF = _PANEL_BUTTON(1)  # disable all panel buttons
 
+# Line display printing
+LINE_DISPLAY_OPEN = ESC + b'\x3d\x02'
+LINE_DISPLAY_CLEAR = ESC + b'\x40'
+LINE_DISPLAY_CLOSE = ESC + b'\x3d\x01'
+
 # Sheet modes
 SHEET_SLIP_MODE = ESC + b'\x63\x30\x04'  # slip paper
 SHEET_ROLL_MODE = ESC + b'\x63\x30\x01'  # paper roll

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -585,6 +585,16 @@ class Escpos(object):
             except:
                 raise CashDrawerError()
 
+    def linedisplay(self, text):
+        """
+        Display text on line display thought your epson printer
+        :param text: Text to display
+        """
+        self._raw(LINE_DISPLAY_OPEN)
+        self._raw(LINE_DISPLAY_CLEAR)
+        self.text(text)
+        self._raw(LINE_DISPLAY_CLOSE)
+
     def hw(self, hw):
         """ Hardware operations
 


### PR DESCRIPTION
This pulls in the changes by @Ousret.
This is useful for setups that have a display in the chain before the printer. It selects the display, resets it, sends text and then again selects the printer.