### PR TITLE
First implementation of software barcode

### DIFF
--- a/examples/software_barcode.py
+++ b/examples/software_barcode.py
@@ -1,5 +1,6 @@
 from escpos.printer import Usb
 
+
 # Adapt to your needs
 p = Usb(0x0416, 0x5011, profile="POS-5890")
 

--- a/examples/software_barcode.py
+++ b/examples/software_barcode.py
@@ -1,0 +1,8 @@
+from escpos.printer import Usb
+
+# Adapt to your needs
+p = Usb(0x0416, 0x5011, profile="POS-5890")
+
+# Some software barcodes
+p.soft_barcode('code128', 'Hello')
+p.soft_barcode('code39', '123456')

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,8 @@ setup(
         'pyyaml',
         'argparse',
         'argcomplete',
-        'future'
+        'future',
+        'pyBarcode==0.8b1'
     ],
     setup_requires=[
         'setuptools_scm',

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
         'argparse',
         'argcomplete',
         'future',
-        'pyBarcode==0.8b1'
+        'viivakoodi>=0.8'
     ],
     setup_requires=[
         'setuptools_scm',

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -19,6 +19,9 @@ import qrcode
 import textwrap
 import six
 
+import barcode
+from barcode.writer import ImageWriter
+
 from .constants import ESC, GS, NUL, QR_ECLEVEL_L, QR_ECLEVEL_M, QR_ECLEVEL_H, QR_ECLEVEL_Q
 from .constants import QR_MODEL_1, QR_MODEL_2, QR_MICRO, BARCODE_TYPES, BARCODE_HEIGHT, BARCODE_WIDTH
 from .constants import TXT_ALIGN_CT, TXT_ALIGN_LT, TXT_ALIGN_RT, BARCODE_FONT_A, BARCODE_FONT_B
@@ -395,6 +398,26 @@ class Escpos(object):
 
         if function_type.upper() == "A":
             self._raw(NUL)
+
+    def soft_barcode(self, barcode_type, data, module_height=5, module_width=0.2, text_distance=1):
+        image_writer = ImageWriter()
+
+        if barcode_type not in barcode.PROVIDED_BARCODES:
+            raise BarcodeTypeError(
+                'Barcode type {} not supported by software barcode renderer'
+                .format(barcode_type))
+
+        barcode_class = barcode.get_barcode_class(barcode_type)
+        my_code = barcode_class(data, writer=image_writer)
+
+        my_code.write("/dev/null", {
+            'module_height': module_height,
+            'module_width': module_width,
+            'text_distance': text_distance
+        })
+
+        image = my_code.writer._image
+        self.image(image, impl='bitImageColumn')
 
     def text(self, txt):
         """ Print alpha-numeric text

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -399,14 +399,18 @@ class Escpos(object):
         if function_type.upper() == "A":
             self._raw(NUL)
 
-    def soft_barcode(self, barcode_type, data, module_height=5, module_width=0.2, text_distance=1):
+    def soft_barcode(self, barcode_type, data, impl='bitImageColumn',
+                     module_height=5, module_width=0.2, text_distance=1):
+
         image_writer = ImageWriter()
 
+        # Check if barcode type exists
         if barcode_type not in barcode.PROVIDED_BARCODES:
             raise BarcodeTypeError(
                 'Barcode type {} not supported by software barcode renderer'
                 .format(barcode_type))
 
+        # Render the barcode to a fake file
         barcode_class = barcode.get_barcode_class(barcode_type)
         my_code = barcode_class(data, writer=image_writer)
 
@@ -416,8 +420,9 @@ class Escpos(object):
             'text_distance': text_distance
         })
 
+        # Retrieve the Pillow image and print it
         image = my_code.writer._image
-        self.image(image, impl='bitImageColumn')
+        self.image(image, impl=impl)
 
     def text(self, txt):
         """ Print alpha-numeric text


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * ZJ5890
- [x] My contribution is ready to be merged as is

----------

### Description

Actually the hardware barcode implementation is very specific and not generic enough for just adding a `soft_render=True` argument to it. This is a first work that can be improved with other commits, maybe for
merging this method in the `barcode` method after some cleanup.

The width, height and text_distance were set using empiric print-and-retry tests so that the generated barcode looks nice to the eye (and to the eye of an Android scanner tool.

!WARNING! Printing a barcode that is too large in width will result in the printer to go crazy trying to print an image that is too large for it. This may be fixed by raising an exception in the `image` method.