### PR TITLE
Added ImageWidthError and its implementation

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -34,6 +34,7 @@ from .constants import CTL_VT, CTL_HT, CTL_CR, CTL_FF, CTL_LF, CTL_SET_HT, PANEL
 
 from .exceptions import BarcodeTypeError, BarcodeSizeError, TabPosError
 from .exceptions import CashDrawerError, SetVariableError, BarcodeCodeError
+from .exceptions import ImageWidthError
 
 from .magicencode import MagicEncode
 
@@ -98,6 +99,14 @@ class Escpos(object):
 
         """
         im = EscposImage(img_source)
+
+        try:
+            max_width =  self.profile.profile_data['media']['width']['pixels']
+            if im.width > max_width:
+                raise ImageWidthError('{} > {}'.format(im.width, max_width))
+        except KeyError:
+            # If the printer's pixel width is not known, print anyways...
+            pass
 
         if im.height > fragment_height:
             fragments = im.split(fragment_height)

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -101,11 +101,14 @@ class Escpos(object):
         im = EscposImage(img_source)
 
         try:
-            max_width = self.profile.profile_data['media']['width']['pixels']
+            max_width = int(self.profile.profile_data['media']['width']['pixels'])
             if im.width > max_width:
                 raise ImageWidthError('{} > {}'.format(im.width, max_width))
         except KeyError:
             # If the printer's pixel width is not known, print anyways...
+            pass
+        except ValueError:
+            # If the max_width cannot be converted to an int, print anyways...
             pass
 
         if im.height > fragment_height:

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -101,7 +101,7 @@ class Escpos(object):
         im = EscposImage(img_source)
 
         try:
-            max_width =  self.profile.profile_data['media']['width']['pixels']
+            max_width = self.profile.profile_data['media']['width']['pixels']
             if im.width > max_width:
                 raise ImageWidthError('{} > {}'.format(im.width, max_width))
         except KeyError:

--- a/src/escpos/exceptions.py
+++ b/src/escpos/exceptions.py
@@ -107,7 +107,7 @@ class ImageSizeError(Error):
 
 class ImageWidthError(Error):
     """ Image width is too large.
-    
+
     The return code for this exception is `41`.
     """
     def __init__(self, msg=""):

--- a/src/escpos/exceptions.py
+++ b/src/escpos/exceptions.py
@@ -8,6 +8,7 @@ Result/Exit codes:
     - `20` = Barcode size values are out of range :py:exc:`~escpos.exceptions.BarcodeSizeError`
     - `30` = Barcode text not supplied :py:exc:`~escpos.exceptions.BarcodeCodeError`
     - `40` = Image height is too large :py:exc:`~escpos.exceptions.ImageSizeError`
+    - `41` = Image width is too large :py:exc:`~escpos.exceptions.ImageWidthError`
     - `50` = No string supplied to be printed :py:exc:`~escpos.exceptions.TextError`
     - `60` = Invalid pin to send Cash Drawer pulse :py:exc:`~escpos.exceptions.CashDrawerError`
     - `70` = Invalid number of tab positions :py:exc:`~escpos.exceptions.TabPosError`
@@ -102,6 +103,20 @@ class ImageSizeError(Error):
 
     def __str__(self):
         return "Image height is longer than 255px and can't be printed ({msg})".format(msg=self.msg)
+
+
+class ImageWidthError(Error):
+    """ Image width is too large.
+    
+    The return code for this exception is `41`.
+    """
+    def __init__(self, msg=""):
+        Error.__init__(self, msg)
+        self.msg = msg
+        self.resultcode = 41
+
+    def __str__(self):
+        return "Image width is too large ({msg})".format(msg=self.msg)
 
 
 class TextError(Error):

--- a/test/test_function_image.py
+++ b/test/test_function_image.py
@@ -12,8 +12,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import escpos.printer as printer
+import pytest
+
 from PIL import Image
+
+import escpos.printer as printer
+from escpos.exceptions import ImageWidthError
 
 
 # Raster format print
@@ -139,3 +143,22 @@ def test_large_graphics():
     instance = printer.Dummy()
     instance.image('test/resources/black_white.png', impl="bitImageRaster", fragment_height=1)
     assert(instance.output == b'\x1dv0\x00\x01\x00\x01\x00\xc0\x1dv0\x00\x01\x00\x01\x00\x00')
+
+
+def test_width_too_large():
+    """
+    Test printing an image that is too large in width.
+    """
+    instance = printer.Dummy()
+    instance.profile.profile_data = {
+        'media': {
+            'width': {
+                'pixels': 384
+            }
+        }
+    }
+
+    with pytest.raises(ImageWidthError):
+        instance.image(Image.new("RGB", (385, 200)))
+
+    instance.image(Image.new("RGB", (384, 200)))


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * ZJ-5890
- [x] My contribution is ready to be merged as is

----------

### Description

This PR address the #217 issue.

Sample tested output on my 384-pixels-wide ZJ-8590 printer:

```
/home/microjoe/.virtualenvs/posprinter/bin/python /home/microjoe/dev/poc/posprinter/hello.py
Traceback (most recent call last):
  File "/home/microjoe/dev/poc/posprinter/hello.py", line 26, in <module>
    p.image('/home/microjoe/desk/microjoe_nok.png', impl='bitImageColumn')
  File "/home/microjoe/dev/github/python-escpos/src/escpos/escpos.py", line 106, in image
    raise ImageWidthError('{} > {}'.format(im.width, max_width))
escpos.exceptions.ImageWidthError: Image width is too large (385 > 384)

Process finished with exit code 1
```

Tested also with 384 wide image and the printing works. I will try to add unit tests to this and then we can merge.