### PR TITLE
README: Lists should not be right-espaced in reST

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,10 @@ Dependencies
 
 This library makes use of:
 
-    * pyusb for USB-printers
-    * Pillow for image printing
-    * qrcode for the generation of QR-codes
-    * pyserial for serial printers
+* pyusb for USB-printers
+* Pillow for image printing
+* qrcode for the generation of QR-codes
+* pyserial for serial printers
 
 Documentation and Usage
 -----------------------


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] My contribution is ready to be merged as is

----------

### Description

List currently appears quoted in README, this PR should fix this bad format.