### PR TITLE
Optional feed for cut (closes #213)

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -563,7 +563,7 @@ class Escpos(object):
 
         self._raw(LINESPACING_FUNCS[divisor] + six.int2byte(spacing))
 
-    def cut(self, mode='FULL'):
+    def cut(self, mode='FULL', feed=True):
         """ Cut paper.
 
         Without any arguments the paper will be cut completely. With 'mode=PART' a partial cut will
@@ -573,9 +573,11 @@ class Escpos(object):
         .. todo:: Check this function on TM-T88II.
 
         :param mode: set to 'PART' for a partial cut. default: 'FULL'
+        :param feed: print and feed before cutting. default: true
         :raises ValueError: if mode not in ('FULL', 'PART')
         """
-        self.print_and_feed(6)
+        if feed:
+            self.print_and_feed(6)
 
         mode = mode.upper()
         if mode not in ('FULL', 'PART'):

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -576,8 +576,12 @@ class Escpos(object):
         :param feed: print and feed before cutting. default: true
         :raises ValueError: if mode not in ('FULL', 'PART')
         """
-        if feed:
-            self.print_and_feed(6)
+
+        if not feed:
+            self._raw(GS + b'V' + six.int2byte(66) + b'\x00')
+            return
+
+        self.print_and_feed(6)
 
         mode = mode.upper()
         if mode not in ('FULL', 'PART'):

--- a/test/test_function_cut.py
+++ b/test/test_function_cut.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import six
+
+import escpos.printer as printer
+from escpos.constants import GS
+
+
+def test_cut_without_feed():
+    """Test cut without feeding paper"""
+    instance = printer.Dummy()
+    instance.cut(feed=False)
+    expected = GS + b'V' + six.int2byte(66) + b'\x00'
+    assert(instance.output == expected)


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [ ] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
- [x] My contribution is ready to be merged as is

----------

### Description

Optional feed. Fixes #213.