### PR TITLE
Added the DLE EOT querying command.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -8,3 +8,4 @@ Cody (Quantified Code Bot) <cody@quantifiedcode.com> Cody <cody@quantifiedcode.c
 Renato Lorenzi <renato.lorenzi@senior.com.br>        Renato.Lorenzi <renato.lorenzi@senior.com.br>
 Ahmed Tahri <nyuubi.10@gmail.com>                    TAHRI Ahmed <nyuubi.10@gmail.com>
 Michael Elsdörfer <michael@elsdoerfer.com>           Michael Elsdörfer <michael@elsdoerfer.info>
+csoft2k <csoft2k@hotmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -10,7 +10,6 @@ Dean Rispin
 Dmytro Katyukha
 Hark
 Joel Lehtonen
-K
 Kristi
 ldos
 Manuel F Martinez

--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -252,5 +252,4 @@ S_RASTER_Q  = _PRINT_RASTER_IMG(b'\x03')  # Set raster image quadruple
 
 # Status Command
 RT_STATUS_ONLINE = DLE + EOT +  b'\x01';
-RT_STATUS_OFFLINECAUSE = DLE + EOT +  b'\x02';
 RT_MASK_ONLINE = 8;

--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -249,3 +249,8 @@ S_RASTER_N  = _PRINT_RASTER_IMG(b'\x00')  # Set raster image normal size
 S_RASTER_2W = _PRINT_RASTER_IMG(b'\x01')  # Set raster image double width
 S_RASTER_2H = _PRINT_RASTER_IMG(b'\x02')  # Set raster image double height
 S_RASTER_Q  = _PRINT_RASTER_IMG(b'\x03')  # Set raster image quadruple
+
+# Status Command
+RT_STATUS_ONLINE = DLE + EOT +  b'\x01';
+RT_STATUS_OFFLINECAUSE = DLE + EOT +  b'\x02';
+RT_MASK_ONLINE = 8;

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 import qrcode
 import textwrap
 import six
+import time
 
 import barcode
 from barcode.writer import ImageWriter
@@ -34,6 +35,7 @@ from .constants import CD_KICK_DEC_SEQUENCE, CD_KICK_5, CD_KICK_2, PAPER_FULL_CU
 from .constants import HW_RESET, HW_SELECT, HW_INIT
 from .constants import CTL_VT, CTL_HT, CTL_CR, CTL_FF, CTL_LF, CTL_SET_HT, PANEL_BUTTON_OFF, PANEL_BUTTON_ON
 from .constants import TXT_STYLE
+from .constants import RT_STATUS_ONLINE, RT_STATUS_OFFLINECAUSE, RT_MASK_ONLINE
 
 from .exceptions import BarcodeTypeError, BarcodeSizeError, TabPosError
 from .exceptions import CashDrawerError, SetVariableError, BarcodeCodeError
@@ -733,6 +735,18 @@ class Escpos(object):
         else:
             self._raw(PANEL_BUTTON_OFF)
 
+    def queryStatus(self):
+        self._raw(RT_STATUS_ONLINE)
+        time.sleep(1)
+        status = self._read();
+        if (len(status) > 0):
+            return status;
+        else:
+            return [8];
+
+    def _isOnline(self):
+        status = self.queryStatus()[0];
+        return ((status & RT_MASK_ONLINE) == 0);
 
 class EscposIO(object):
     """ESC/POS Printer IO object

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -79,6 +79,9 @@ class Escpos(object):
         """
         pass
 
+    def _read(self, msg):
+        raise NotImplementedError(); 
+
     def image(self, img_source, high_density_vertical=True, high_density_horizontal=True, impl="bitImageRaster",
               fragment_height=960):
         """ Print an image
@@ -744,7 +747,7 @@ class Escpos(object):
         else:
             return [8];
 
-    def _isOnline(self):
+    def isOnline(self):
         status = self.queryStatus()[0];
         return ((status & RT_MASK_ONLINE) == 0);
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -35,7 +35,7 @@ from .constants import CD_KICK_DEC_SEQUENCE, CD_KICK_5, CD_KICK_2, PAPER_FULL_CU
 from .constants import HW_RESET, HW_SELECT, HW_INIT
 from .constants import CTL_VT, CTL_HT, CTL_CR, CTL_FF, CTL_LF, CTL_SET_HT, PANEL_BUTTON_OFF, PANEL_BUTTON_ON
 from .constants import TXT_STYLE
-from .constants import RT_STATUS_ONLINE, RT_STATUS_OFFLINECAUSE, RT_MASK_ONLINE
+from .constants import RT_STATUS_ONLINE, RT_MASK_ONLINE
 
 from .exceptions import BarcodeTypeError, BarcodeSizeError, TabPosError
 from .exceptions import CashDrawerError, SetVariableError, BarcodeCodeError
@@ -80,7 +80,10 @@ class Escpos(object):
         pass
 
     def _read(self, msg):
-        raise NotImplementedError(); 
+        """ Returns a NotImplementedError if the instance of the class doesn't override this method.
+        :raises NotImplementedError
+        """
+        raise NotImplementedError()
 
     def image(self, img_source, high_density_vertical=True, high_density_horizontal=True, impl="bitImageRaster",
               fragment_height=960):
@@ -738,18 +741,20 @@ class Escpos(object):
         else:
             self._raw(PANEL_BUTTON_OFF)
 
-    def queryStatus(self):
+    def query_status(self):
+        """ Queries the printer for its status, and returns an array of integers containing it.
+        :rtype: array(integer)"""
         self._raw(RT_STATUS_ONLINE)
         time.sleep(1)
-        status = self._read();
-        if (len(status) > 0):
-            return status;
-        else:
-            return [8];
+        status = self._read()
+        return status or [8]
 
-    def isOnline(self):
-        status = self.queryStatus()[0];
-        return ((status & RT_MASK_ONLINE) == 0);
+    def is_online(self):
+        """ Queries the printer its online status.
+        When online, returns True; False otherwise.
+        :rtype: bool: True if online, False if offline."""
+        return (self.query_status()[0] & RT_MASK_ONLINE) == 0
+
 
 class EscposIO(object):
     """ESC/POS Printer IO object

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -747,13 +747,13 @@ class Escpos(object):
         self._raw(RT_STATUS_ONLINE)
         time.sleep(1)
         status = self._read()
-        return status or [8]
+        return status or [RT_MASK_ONLINE]
 
     def is_online(self):
         """ Queries the printer its online status.
         When online, returns True; False otherwise.
         :rtype: bool: True if online, False if offline."""
-        return (self.query_status()[0] & RT_MASK_ONLINE) == 0
+        return not (self.query_status()[0] & RT_MASK_ONLINE)
 
 
 class EscposIO(object):

--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -84,6 +84,10 @@ class Usb(Escpos):
         """
         self.device.write(self.out_ep, msg, self.timeout)
 
+    def _read(self):
+        """ Reads a data buffer and returns it to the caller. """
+        return self.device.read(self.in_ep, 16)
+
     def close(self):
         """ Release USB interface """
         if self.device:


### PR DESCRIPTION
Added a function to check whether the printer is online or not, as well
as a reading method for USB printers.

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices: Epson TM-T20II
- [x] My contribution is ready to be merged as is

----------

### Description
As of now this module lacked a reading capability to check the status of the printers.
I thought it could be great to be able to check if the printer is online or not.
This can be achieved by invoking the printer._isOnline() method, which returns a Boolean - if True, the printer is (obviously...) online.
I've only been able to develop this in the Usb class, since I lack any other interfaces for my printer.