### PR TITLE
Paper sensor querying command

### DIFF
--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -251,5 +251,10 @@ S_RASTER_2H = _PRINT_RASTER_IMG(b'\x02')  # Set raster image double height
 S_RASTER_Q  = _PRINT_RASTER_IMG(b'\x03')  # Set raster image quadruple
 
 # Status Command
-RT_STATUS_ONLINE = DLE + EOT +  b'\x01';
-RT_MASK_ONLINE = 8;
+RT_STATUS = DLE + EOT
+RT_STATUS_ONLINE = RT_STATUS +  b'\x01'
+RT_STATUS_PAPER = RT_STATUS +  b'\x04'
+RT_MASK_ONLINE = 8
+RT_MASK_PAPER = 18
+RT_MASK_LOWPAPER = 30
+RT_MASK_NOPAPER = 114

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -756,8 +756,7 @@ class Escpos(object):
 
     def query_status(self, mode):
         """ Queries the printer for its status, and returns an array of integers containing it.
-        :param mode: Querying command to be sent to the printer.
-        Available commands:
+        :param mode: Integer that sets the status mode queried to the printer.
         RT_STATUS_ONLINE: Printer status.
         RT_STATUS_PAPER: Paper sensor.
         :rtype: array(integer)"""
@@ -770,7 +769,7 @@ class Escpos(object):
         """ Queries the printer its online status.
         When online, returns True; False otherwise.
         :rtype: bool: True if online, False if offline."""
-        status = self.query_status(RT_STATUS_ONLINE)
+        status = self.query_status(RT_STATUS_ONLINE);
         if len(status) == 0:
             return False;
         return not (status & RT_MASK_ONLINE)

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -35,7 +35,8 @@ from .constants import CD_KICK_DEC_SEQUENCE, CD_KICK_5, CD_KICK_2, PAPER_FULL_CU
 from .constants import HW_RESET, HW_SELECT, HW_INIT
 from .constants import CTL_VT, CTL_CR, CTL_FF, CTL_LF, CTL_SET_HT, PANEL_BUTTON_OFF, PANEL_BUTTON_ON
 from .constants import TXT_STYLE
-from .constants import RT_STATUS_ONLINE, RT_MASK_ONLINE, RT_STATUS_PAPER, RT_MASK_PAPER, RT_MASK_LOWPAPER, RT_MASK_NOPAPER
+from .constants import RT_STATUS_ONLINE, RT_MASK_ONLINE
+from .constants import RT_STATUS_PAPER, RT_MASK_PAPER, RT_MASK_LOWPAPER, RT_MASK_NOPAPER
 
 from .exceptions import BarcodeTypeError, BarcodeSizeError, TabPosError
 from .exceptions import CashDrawerError, SetVariableError, BarcodeCodeError
@@ -769,9 +770,9 @@ class Escpos(object):
         """ Queries the printer its online status.
         When online, returns True; False otherwise.
         :rtype: bool: True if online, False if offline."""
-        status = self.query_status(RT_STATUS_ONLINE);
+        status = self.query_status(RT_STATUS_ONLINE)
         if len(status) == 0:
-            return False;
+            return False
         return not (status & RT_MASK_ONLINE)
 
     def paper_status(self):

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -35,7 +35,7 @@ from .constants import CD_KICK_DEC_SEQUENCE, CD_KICK_5, CD_KICK_2, PAPER_FULL_CU
 from .constants import HW_RESET, HW_SELECT, HW_INIT
 from .constants import CTL_VT, CTL_CR, CTL_FF, CTL_LF, CTL_SET_HT, PANEL_BUTTON_OFF, PANEL_BUTTON_ON
 from .constants import TXT_STYLE
-from .constants import RT_STATUS_ONLINE, RT_MASK_ONLINE
+from .constants import RT_STATUS_ONLINE, RT_MASK_ONLINE, RT_STATUS_PAPER, RT_MASK_PAPER, RT_MASK_LOWPAPER, RT_MASK_NOPAPER
 
 from .exceptions import BarcodeTypeError, BarcodeSizeError, TabPosError
 from .exceptions import CashDrawerError, SetVariableError, BarcodeCodeError
@@ -754,19 +754,41 @@ class Escpos(object):
         else:
             self._raw(PANEL_BUTTON_OFF)
 
-    def query_status(self):
+    def query_status(self, mode):
         """ Queries the printer for its status, and returns an array of integers containing it.
+        :param mode: Querying command to be sent to the printer.
+        Available commands:
+        RT_STATUS_ONLINE: Printer status.
+        RT_STATUS_PAPER: Paper sensor.
         :rtype: array(integer)"""
-        self._raw(RT_STATUS_ONLINE)
+        self._raw(mode)
         time.sleep(1)
         status = self._read()
-        return status or [RT_MASK_ONLINE]
+        return status
 
     def is_online(self):
         """ Queries the printer its online status.
         When online, returns True; False otherwise.
         :rtype: bool: True if online, False if offline."""
-        return not (self.query_status()[0] & RT_MASK_ONLINE)
+        status = self.query_status(RT_STATUS_ONLINE)
+        if len(status) == 0:
+            return False;
+        return not (status & RT_MASK_ONLINE)
+
+    def paper_status(self):
+        """ Queries the printer its paper status.
+        Returns 2 if there is plenty of paper, 1 if the paper has arrived to
+        the near-end sensor and 0 if there is no paper.
+        :rtype: int: 2: Paper is adequate. 1: Paper ending. 0: No paper."""
+        status = self.query_status(RT_STATUS_PAPER)
+        if len(status) == 0:
+            return 2
+        if (status[0] & RT_MASK_NOPAPER == RT_MASK_NOPAPER):
+            return 0
+        if (status[0] & RT_MASK_LOWPAPER == RT_MASK_LOWPAPER):
+            return 1
+        if (status[0] & RT_MASK_PAPER == RT_MASK_PAPER):
+            return 2
 
 
 class EscposIO(object):


### PR DESCRIPTION
The DLE EOT command allows querying the status of several features of
the printer.
Added to the online/offline status developed in #237, this commit adds a
paper sensor querying.

Tested with an Epson TM-T20II, which only has an end-paper sensor. The
near-end paper sensor should be tested with a compatible printer.
However, the implementation is quite straight-forward.

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * e.g. Epson TM-T88II
- [x] My contribution is ready to be merged as is

----------

### Description

fixes #143 
