### PR TITLE
fix docs failing due to pickle protocol in mixed env

### DIFF
--- a/src/escpos/capabilities.py
+++ b/src/escpos/capabilities.py
@@ -38,7 +38,7 @@ if full_load:
     logger.debug('Loading and pickling capabilities')
     with open(capabilities_path) as cp, open(pickle_path, 'wb') as pp:
         CAPABILITIES = yaml.load(cp)
-        pickle.dump(CAPABILITIES, pp)
+        pickle.dump(CAPABILITIES, pp, protocol=2)
 
 logger.debug('Finished loading capabilities took %.2fs', time.time() - t0)
 


### PR DESCRIPTION
When executing a tox-run a pickle file will be created. If the docs are
built after the py3 task, it will fail due to incompatible
pickle-protocols.
See https://stackoverflow.com/a/25843743/4244236 for reference.

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] My contribution is ready to be merged as is

