### PR TITLE
Feature/clear content in dummy printer

### DIFF
--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -312,5 +312,13 @@ class Dummy(Escpos):
         """ Get the data that was sent to this printer """
         return b''.join(self._output_list)
 
+    def clear(self):
+        """ Clear the buffer of the printer
+
+        This method can be called if you send the contents to a physical printer
+        and want to use the Dummy printer for new output.
+        """
+        del self._output_list[:]
+
     def close(self):
         pass

--- a/test/test_function_dummy_clear.py
+++ b/test/test_function_dummy_clear.py
@@ -1,0 +1,8 @@
+from nose.tools import assert_raises
+from escpos.printer import Dummy
+
+def test_printer_dummy_clear():
+    printer = Dummy()
+    printer.text("Hello")
+    printer.clear()
+    assert(printer.output == b'')


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * POS-5890T
- [x] My contribution is ready to be merged as is

----------

### Description
When using the dummy printer as caching device, you can send the output to a physical device. But the reusing the same dummy device would result in appending the new output to already printed output. To overcome this issue, the clear function is implemented, which clears the current buffer.