### PR TITLE
Modified submodule to always pull from master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "capabilities-data"]
 	path = capabilities-data
 	url = https://github.com/receipt-print-hq/escpos-printer-db.git
+	branch = master


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * POS-5890C
- [x] My contribution is ready to be merged as is

----------

### Description
capabilities-data is outdated. I have updated the submodule to use the current master branch, and modified .gitmodule to also use the [master branch](https://github.com/receipt-print-hq/escpos-printer-db/tree/master) as well.