### PR TITLE
parameter for implementation of nonnative qrcode

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -180,7 +180,7 @@ class Escpos(object):
         self._raw(GS + b'(L' + header + m + fn + data)
 
     def qr(self, content, ec=QR_ECLEVEL_L, size=3, model=QR_MODEL_2,
-           native=False, center=False):
+           native=False, center=False, impl="bitImageRaster"):
         """ Print QR Code for the provided string
 
         :param content: The content of the code. Numeric data will be more efficiently compacted.
@@ -222,7 +222,7 @@ class Escpos(object):
 
             # Convert the RGB image in printable image
             self.text('\n')
-            self.image(im, center=center)
+            self.image(im, center=center, impl=impl)
             self.text('\n')
             self.text('\n')
             return


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [X] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * Custom Q3X
- [X] My contribution is ready to be merged as is

----------

### Description
Custom printers have problems printing images in bitImageRaster, sometime they print 2 times the image, or a piece of it.
They don't support native qrcode, so I needed to print nonNative qrcode with bitImageColumn implementation

I just exposed the impl paramin qr, to be used in nonnative implementations