### PR TITLE
Allow arbitrary USB args

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Curtis // mashedkeyboard
 Davis Goglin
 Dean Rispin
 Dmytro Katyukha
+Gerard Marull-Paretas
 Hark
 Joel Lehtonen
 kennedy

--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -34,27 +34,39 @@ class Usb(Escpos):
 
     """
 
-    def __init__(self, idVendor, idProduct, timeout=0, in_ep=0x82, out_ep=0x01, *args, **kwargs):  # noqa: N803
+    def __init__(self, idVendor, idProduct, usb_args=None, timeout=0, in_ep=0x82, out_ep=0x01,
+                 *args, **kwargs):  # noqa: N803
         """
         :param idVendor: Vendor ID
         :param idProduct: Product ID
+        :param usb_args: Optional USB arguments (e.g. custom_match)
         :param timeout: Is the time limit of the USB operation. Default without timeout.
         :param in_ep: Input end point
         :param out_ep: Output end point
         """
         Escpos.__init__(self, *args, **kwargs)
-        self.idVendor = idVendor
-        self.idProduct = idProduct
         self.timeout = timeout
         self.in_ep = in_ep
         self.out_ep = out_ep
-        self.open()
 
-    def open(self):
-        """ Search device on USB tree and set it as escpos device """
-        self.device = usb.core.find(idVendor=self.idVendor, idProduct=self.idProduct)
+        usb_args = usb_args or {}
+        if idVendor:
+            usb_args['idVendor'] = idVendor
+        if idProduct:
+            usb_args['idProduct'] = idProduct
+        self.open(usb_args)
+
+    def open(self, usb_args):
+        """ Search device on USB tree and set it as escpos device.
+
+        :param usb_args: USB arguments
+        """
+        self.device = usb.core.find(**usb_args)
         if self.device is None:
             raise USBNotFoundError("Device not found or cable not plugged in.")
+
+        self.idVendor = self.device.idVendor
+        self.idProduct = self.device.idProduct
 
         check_driver = None
 


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * POS-5890
- [x] My contribution is ready to be merged as is

----------

### Description

This change allows to pass arbitrary arguments to `usb.core.find`. This can be useful, for example, to pass a custom matcher and therefore be able to instantiate 2 printers with the same vid/pid connected on the same PC.

Note that public API is left unchanged.
