### PR TITLE
Enable Windows Support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Michael Billington
 Michael Elsdörfer
 mrwunderbar666
 Nathan Bookham
+Omer Akram
 Patrick Kanzler
 primax79
 Qian Linfeng

--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -72,7 +72,7 @@ class Usb(Escpos):
         # only libusb1 backend implements the methods is_kernel_driver_active()
         # and detach_kernel_driver(). This change helps enable this
         # library to work on Windows.
-        if sef.device.backend.__module__.endswith("libusb1"):
+        if self.device.backend.__module__.endswith("libusb1"):
             check_driver = None
 
             try:

--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -17,7 +17,6 @@ import usb.core
 import usb.util
 import serial
 import socket
-import sys
 
 from .escpos import Escpos
 from .exceptions import USBNotFoundError
@@ -69,9 +68,11 @@ class Usb(Escpos):
         self.idVendor = self.device.idVendor
         self.idProduct = self.device.idProduct
 
-        # detach_kernel_driver() doesn't really work on Windows,
-        # causing the library to not work on that platform.
-        if sys.platform != 'win32':
+        # pyusb has three backends: libusb0, libusb1 and openusb but
+        # only libusb1 backend implements the methods is_kernel_driver_active()
+        # and detach_kernel_driver(). This change helps enable this
+        # library to work on Windows.
+        if sef.device.backend.__module__.endswith("libusb1"):
             check_driver = None
 
             try:

--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -70,8 +70,8 @@ class Usb(Escpos):
 
         # pyusb has three backends: libusb0, libusb1 and openusb but
         # only libusb1 backend implements the methods is_kernel_driver_active()
-        # and detach_kernel_driver(). This change helps enable this
-        # library to work on Windows.
+        # and detach_kernel_driver().
+        # This helps enable this library to work on Windows.
         if self.device.backend.__module__.endswith("libusb1"):
             check_driver = None
 


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * XPrinter XP-E200L
- [x] My contribution is ready to be merged as is

----------

### Description
`is_kernel_driver_active()` and `detach_kernel_driver()` are only implemented in `libusb1` this change makes this library work with `libusb0` as well, which is installed by [zadig](https://zadig.akeo.ie/) on Windows. 


Edit:
closes #274 
fixes #316 
fixes #299