### PR TITLE
Update to use pyyaml safe_load()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Dmytro Katyukha
 Gerard Marull-Paretas
 Hark
 Joel Lehtonen
+Justin Vieira
 kennedy
 Kristi
 ldos

--- a/src/escpos/capabilities.py
+++ b/src/escpos/capabilities.py
@@ -38,7 +38,7 @@ else:
 if full_load:
     logger.debug('Loading and pickling capabilities')
     with open(capabilities_path) as cp, open(pickle_path, 'wb') as pp:
-        CAPABILITIES = yaml.load(cp)
+        CAPABILITIES = yaml.safe_load(cp)
         pickle.dump(CAPABILITIES, pp, protocol=2)
 
 logger.debug('Finished loading capabilities took %.2fs', time.time() - t0)


### PR DESCRIPTION
### Contributor checklist
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 Epson TM-T88III
- [x] My contribution is ready to be merged as is

----------

### Description
Update to use pyyaml safe_load() instead of load(), which is now [deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

load() is now considered unsafe, due to [this code execution insecurity](https://seclists.org/oss-sec/2018/q2/240), which is why it is now deprecated.

load() is also now disabled on Gentoo linux systems - see [the bug report here](https://bugs.gentoo.org/659348).