### PR TITLE
release v3.0a6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,23 @@ env:
   global:
     - ESCPOS_CAPABILITIES_FILE=/home/travis/build/python-escpos/python-escpos/capabilities-data/dist/capabilities.json
 matrix:
+  fast_finish: true
   include:
+    - name: "Python 3.7 on Windows"
+      os: windows
+      language: shell
+      before_install:
+         - choco install python
+         - pip install tox codecov 'sphinx>=1.5.1'
+      env:
+         - TOXENV=py37
+         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+         - ESCPOS_CAPABILITIES_FILE=C:/Users/travis/build/python-escpos/python-escpos/capabilities-data/dist/capabilities.json
+    - name: "Python 3.7 on macOS"
+      os: osx
+      osx_image: xcode10.2
+      language: shell
+      env: TOXENV=py37 ESCPOS_CAPABILITIES_FILE=/Users/travis/build/python-escpos/python-escpos/capabilities-data/dist/capabilities.json
     - python: 2.7
       env: TOXENV=py27
     - python: 3.4
@@ -40,11 +56,14 @@ matrix:
     - python: 3.7
       env: TOXENV=flake8
   allow_failures:
+    - python: 2.7
     - python: 3.6-dev
     - python: 3.7-dev
     - python: 3.8-dev
     - python: nightly
     - python: pypy3
+    - os: windows
+    - os: osx
 before_install:
     - pip install tox codecov 'sphinx>=1.5.1'
     - ./doc/generate_authors.sh --check

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,22 @@
 *********
 Changelog
 *********
+2019-06-19 - Version 3.0a6 - "Mistake not..."
+---------------------------------------------
+This release is the seventh alpha release of the new version 3.0.
+Please be aware the the API is subject to change until v3.0 is
+released.
+
+changes
+^^^^^^^
+- fix inclusion of the capabilities-file
+- execute CI jobs also on Windows and macOS-targets
+- improve documentation
+
+contributors
+^^^^^^^^^^^^
+- Patrick Kanzler
+
 2019-06-16 - Version 3.0a5 - "Lightly Seared On The Reality Grill"
 ------------------------------------------------------------------
 This release is the sixth alpha release of the new version 3.0. Please

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include *.rst
 include *.txt
-include COPYING
 include LICENSE
 include INSTALL
 include tox.ini

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     platforms='any',
     package_dir={"": "src"},
     packages=find_packages(where="src", exclude=["tests", "tests.*"]),
-    package_data={'': ['COPYING', 'src/escpos/capabilities.json']},
+    package_data={'escpos': ['capabilities.json']},
     include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -195,6 +195,7 @@ class Escpos(object):
         :param native: True to render the code on the printer, False to render the code as an image and send it to the
             printer (Default)
         :param center: Centers the code *default:* False
+        :param impl: Image-printing-implementation, refer to :meth:`.image()` for details
         """
         # Basic validation
         if ec not in [QR_ECLEVEL_L, QR_ECLEVEL_M, QR_ECLEVEL_H, QR_ECLEVEL_Q]:
@@ -306,8 +307,8 @@ class Escpos(object):
         .. todo:: For fixed-length standards with mandatory checksum (EAN, UPC),
             compute and add the checksum automatically if missing.
 
-        :param bc: barcode format, see :py:func`~escpos.Escpos.barcode`
-        :param code: alphanumeric data to be printed as bar code, see :py:func`~escpos.Escpos.barcode`
+        :param bc: barcode format, see :py:meth:`.barcode()`
+        :param code: alphanumeric data to be printed as bar code, see :py:meth:`.barcode()`
         :return: bool
         """
         if bc not in BARCODE_FORMATS:
@@ -394,7 +395,7 @@ class Escpos(object):
             *default*: A
 
         :param check: If this parameter is True, the barcode format will be checked to ensure it meets the bc
-            requirements as defigned in the esc/pos documentation. See py:func:`~escpos.Escpos.check_barcode`
+            requirements as defigned in the esc/pos documentation. See :py:meth:`.check_barcode()`
             for more information. *default*: True.
 
         :raises: :py:exc:`~escpos.exceptions.BarcodeSizeError`,


### PR DESCRIPTION
This release is the seventh alpha release of the new version 3.0.
Please be aware the the API is subject to change until v3.0 is
released.

### changes
- fix inclusion of the capabilities-file
- execute CI jobs also on Windows and macOS-targets
- improve documentation

### contributors
- Patrick Kanzler