### PR TITLE
Adding except NotImplementedError for 'detach_kernel_driver' in order…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,4 +36,5 @@ Sergio Pulgarin
 Stephan Sokolow
 Thijs Triemstra
 Thomas van den Berg
+Yaisel Hurtado
 ysuolmai

--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -8,15 +8,12 @@
 :license: MIT
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import usb.core
-import usb.util
 import serial
 import socket
+import usb.core
+import usb.util
 
 from .escpos import Escpos
 from .exceptions import USBNotFoundError
@@ -83,6 +80,8 @@ class Usb(Escpos):
             if check_driver is None or check_driver:
                 try:
                     self.device.detach_kernel_driver(0)
+                except NotImplementedError:
+                    pass
                 except usb.core.USBError as e:
                     if check_driver is not None:
                         print("Could not detatch kernel driver: {0}".format(str(e)))
@@ -349,6 +348,7 @@ class Dummy(Escpos):
 _WIN32PRINT = False
 try:
     import win32print
+
     _WIN32PRINT = True
 except ImportError:
     pass


### PR DESCRIPTION
… to avoid the exception NotImplementedError: Operation not supported or unimplemented on this platform.

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * Epson TM-T20II (from Windows 8.1 and Windows 10 using Python 3.7.3 64bits)
- [x] My contribution is ready to be merged as is

----------

### Description
Before the fix...
![error_message](https://user-images.githubusercontent.com/3885141/60307578-3f7b8a00-9913-11e9-997b-65d6d2ab5f30.jpeg)
