### PR TITLE
replace viivakoodi with python-barcode, center soft barcodes by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ This library makes use of:
 * `Pillow <https://github.com/python-pillow/Pillow>`_ for image printing
 * `qrcode <https://github.com/lincolnloop/python-qrcode>`_ for the generation of QR-codes
 * `pyserial <https://github.com/pyserial/pyserial>`_ for serial printers
-* `viivakoodi <https://github.com/kxepal/viivakoodi>`_ for the generation of barcodes
+* `python-barcode <https://github.com/WhyNotHugo/python-barcode>`_ for the generation of barcodes
 
 Documentation and Usage
 -----------------------

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,4 +5,4 @@ pyserial
 sphinx-rtd-theme
 setuptools-scm
 docutils>=0.12
-viivakoodi
+python-barcode>=0.11.0,<1

--- a/examples/software_barcode.py
+++ b/examples/software_barcode.py
@@ -6,4 +6,4 @@ p = Usb(0x0416, 0x5011, profile="POS-5890")
 
 # Some software barcodes
 p.soft_barcode('code128', 'Hello')
-p.soft_barcode('code39', '123456')
+p.soft_barcode('code39', '1234')

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     Pillow>=2.0
     qrcode>=4.0
     pyserial
+    python-barcode>=0.9.1,<1
     six
     appdirs
     PyYAML

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -479,7 +479,8 @@ class Escpos(object):
             self._raw(NUL)
 
     def soft_barcode(self, barcode_type, data, impl='bitImageColumn',
-                     module_height=5, module_width=0.2, text_distance=1):
+                     module_height=5, module_width=0.2, text_distance=1,
+                     center=True):
 
         image_writer = ImageWriter()
 
@@ -502,7 +503,7 @@ class Escpos(object):
 
         # Retrieve the Pillow image and print it
         image = my_code.writer._image
-        self.image(image, impl=impl)
+        self.image(image, impl=impl, center=center)
 
     def text(self, txt):
         """ Print alpha-numeric text

--- a/test/test_function_barcode.py
+++ b/test/test_function_barcode.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 import escpos.printer as printer
-from escpos.constants import BARCODE_TYPE_A, BARCODE_TYPE_B
 from escpos.capabilities import Profile, BARCODE_B
 from escpos.exceptions import BarcodeTypeError, BarcodeCodeError
 import pytest

--- a/test/test_function_softbarcode.py
+++ b/test/test_function_softbarcode.py
@@ -4,9 +4,11 @@ import escpos.printer as printer
 import pytest
 
 
-def test_soft_barcode():
-    """just execute soft_barcode
-    """
-    instance = printer.Dummy()
+@pytest.fixture
+def instance():
+    return printer.Dummy()
+
+
+def test_soft_barcode_ean8(instance):
     instance.soft_barcode("ean8", "1234")
 

--- a/test/test_function_softbarcode.py
+++ b/test/test_function_softbarcode.py
@@ -12,3 +12,6 @@ def instance():
 def test_soft_barcode_ean8(instance):
     instance.soft_barcode("ean8", "1234")
 
+
+def test_soft_barcode_ean8_nocenter(instance):
+    instance.soft_barcode("ean8", "1234", center=False)

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps = nose
        pytest-cov
        pytest-mock
        hypothesis>4
+       python-barcode
        viivakoodi
 commands = pytest --cov escpos
 passenv = ESCPOS_CAPABILITIES_PICKLE_DIR ESCPOS_CAPABILITIES_FILE CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
@@ -27,7 +28,7 @@ basepython = python
 changedir = doc
 deps = sphinx>=1.5.1
        setuptools_scm
-       viivakoodi
+       python-barcode
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
 [testenv:flake8]


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * POS-5890
- [x] My contribution is ready to be merged as is

----------

### Description

This introduces python-barcode as a replacement for viivakoodi. It is a maintained fork of pyBarcode that is focusing on Python 3 only, so that double version support code can be dropped, and code can be cleaned. At least one new codebar type is implemented (GS1-128).

It also introduces the possibility to center the barcode, something that is already possible with `qr_code` function. It will just pass the `center` option to the `image` function, but I decided to make it `True` by default because I do not see any reason why the barcode should *not* be centered on the paper.

Also, the barcode-related tests has been updated a little bit.