### PR TITLE
use pkg_resources

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,7 @@ Pillow>=2.0
 qrcode>=4.0
 pyserial
 sphinx-rtd-theme
+setuptools
 setuptools-scm
 docutils>=0.12
 python-barcode>=0.11.0,<1

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     qrcode>=4.0
     pyserial
     python-barcode>=0.9.1,<1
+    setuptools
     six
     appdirs
     PyYAML

--- a/src/escpos/capabilities.py
+++ b/src/escpos/capabilities.py
@@ -1,5 +1,6 @@
 import re
 from os import environ, path
+import pkg_resources
 import pickle
 import logging
 import time
@@ -15,9 +16,9 @@ logger = logging.getLogger(__name__)
 
 pickle_dir = environ.get('ESCPOS_CAPABILITIES_PICKLE_DIR', gettempdir())
 pickle_path = path.join(pickle_dir, '{v}.capabilities.pickle'.format(v=platform.python_version()))
-capabilities_path = environ.get(
-    'ESCPOS_CAPABILITIES_FILE',
-    path.join(path.dirname(__file__), 'capabilities.json'))
+# get a temporary file from pkg_resources if no file is specified in env
+capabilities_path = environ.get('ESCPOS_CAPABILITIES_FILE',
+                                pkg_resources.resource_filename(__name__, 'capabilities.json'))
 
 # Load external printer database
 t0 = time.time()


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * e.g. Dummy printer
- [x] My contribution is ready to be merged as is

----------

### Description
This change uses if no path for e capabilities-file is supplied a
temporary file created by pkg_resources, which should be more robust
than directly accessing the file. (This failed sometimes, for example
in zipped distributions or uncommon structures)

fixes #396 
related to #391