### PR TITLE
omit env for capabilities on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ addons:
     packages:
       - graphviz
       - libenchant1c2a
-env:
-  global:
-    - ESCPOS_CAPABILITIES_FILE=/home/travis/build/python-escpos/python-escpos/capabilities-data/dist/capabilities.json
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] My contribution is ready to be merged as is

----------

### Description
This removes on the linux based tests the path variable to the capabilities, as the package should now work without this.