### PR TITLE
Update escpos.py

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -539,7 +539,7 @@ class Escpos(object):
         if count > 0:
             self.text('\n' * count)
 
-    def block_text(self, txt, font=None, columns=None):
+    def block_text(self, txt, font="0", columns=None):
         """ Text is printed wrapped to specified columns
 
         Text has to be encoded in unicode.


### PR DESCRIPTION
Set block_text to use the default font. This means calls will wrap to full paper width.

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
   ZJ-5870
- [x] My contribution is ready to be merged as is

----------

### Description
This is just a tiny tweak to allow calls to printer.block_text(mytext) using the default font and full paper width.