### PR TITLE
add call to self.open() to get physical printer works.

### DIFF
--- a/src/escpos/printer.py
+++ b/src/escpos/printer.py
@@ -364,6 +364,7 @@ if _WIN32PRINT:
             else:
                 self.printer_name = win32print.GetDefaultPrinter()
             self.hPrinter = None
+            self.open()
 
         def open(self, job_name="python-escpos"):
             if self.printer_name is None:


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 POSline IT 1260
- [x] My contribution is ready to be merged as is

----------

### Description

without the call to open function, the printer isn't initialize to print, i tested on a generic physical printer.
