### PR TITLE
Add support for slip/cheque dot matrix printers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,11 @@
 Ahmed Tahri
 akeonly
+Alejandro Hernández
 Alexander Bougakov
 Alex Debiasio
 Asuki Kono
 belono
+B. Howell
 Brian
 Christoph Heuel
 Cody (Quantified Code Bot)
@@ -11,6 +13,7 @@ csoft2k
 Curtis // mashedkeyboard
 Davis Goglin
 Dean Rispin
+dependabot[bot]
 Dmytro Katyukha
 Gerard Marull-Paretas
 Hark
@@ -21,6 +24,7 @@ Kristi
 ldos
 Lucy Linder
 Manuel F Martinez
+Mathieu Poussin
 Maximilian Wagenbach
 Michael Billington
 Michael Elsdörfer

--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -77,6 +77,12 @@ LINE_DISPLAY_CLOSE = ESC + b"\x3d\x01"
 SHEET_SLIP_MODE = ESC + b"\x63\x30\x04"  # slip paper
 SHEET_ROLL_MODE = ESC + b"\x63\x30\x01"  # paper roll
 
+# Slip specific codes
+SLIP_EJECT = ESC + b"\x4b\xc0" # Eject the slip or cheque
+SLIP_SELECT = FS # Select the slip station as default station
+SLIP_SET_WAIT_TIME = ESC + b"\x1b\x66" # Set timeout waiting for a slip/cheque to be inserted
+SLIP_PRINT_AND_EJECT = b"\x0c" # Print the buffer and eject (after waiting for the paper to be inserted)
+
 # Text format
 # TODO: Acquire the "ESC/POS Application Programming Guide for Paper Roll
 #       Printers" and tidy up this stuff too.

--- a/src/escpos/constants.py
+++ b/src/escpos/constants.py
@@ -78,10 +78,14 @@ SHEET_SLIP_MODE = ESC + b"\x63\x30\x04"  # slip paper
 SHEET_ROLL_MODE = ESC + b"\x63\x30\x01"  # paper roll
 
 # Slip specific codes
-SLIP_EJECT = ESC + b"\x4b\xc0" # Eject the slip or cheque
-SLIP_SELECT = FS # Select the slip station as default station
-SLIP_SET_WAIT_TIME = ESC + b"\x1b\x66" # Set timeout waiting for a slip/cheque to be inserted
-SLIP_PRINT_AND_EJECT = b"\x0c" # Print the buffer and eject (after waiting for the paper to be inserted)
+SLIP_EJECT = ESC + b"\x4b\xc0"  # Eject the slip or cheque
+SLIP_SELECT = FS  # Select the slip station as default station
+SLIP_SET_WAIT_TIME = (
+    ESC + b"\x1b\x66"
+)  # Set timeout waiting for a slip/cheque to be inserted
+SLIP_PRINT_AND_EJECT = (
+    b"\x0c"  # Print the buffer and eject (after waiting for the paper to be inserted)
+)
 
 # Text format
 # TODO: Acquire the "ESC/POS Application Programming Guide for Paper Roll

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -1016,14 +1016,12 @@ class Escpos(object):
         if status[0] & RT_MASK_PAPER == RT_MASK_PAPER:
             return 2
 
-    """
-    Select where to print to
-
-    Print to the thermal printer by default (ROLL) or
-    print to the slip dot matrix printer if supported (SLIP)
-    """
-
     def target(self, type="ROLL"):
+        """Select where to print to
+
+        Print to the thermal printer by default (ROLL) or
+        print to the slip dot matrix printer if supported (SLIP)
+        """
         if type.upper() == "ROLL":
             self._raw(SHEET_ROLL_MODE)
         elif type.upper() == "SLIP":
@@ -1031,29 +1029,26 @@ class Escpos(object):
         else:
             raise ValueError("Unsupported target")
 
-    """
-    Eject the slip/cheque
-    """
-
     def eject_slip(self):
+        """Eject the slip/cheque"""
         self._raw(SLIP_EJECT)
 
-    """
-    Prints data from the buffer to the slip station and if the paper sensor is covered,
-    reverses the slip out the front of the printer far enough to be accessible to the operator.
-    The impact station opens the platen in all cases.
-    """
-
     def print_and_eject_slip(self):
+        """Print and eject
+
+        Prints data from the buffer to the slip station and if the paper
+        sensor is covered, reverses the slip out the front of the printer
+        far enough to be accessible to the operator.
+        The impact station opens the platen in all cases.
+        """
         self._raw(SLIP_PRINT_AND_EJECT)
 
-    """
-    Selects the Slip Station for all functions.
-    The receipt station is the default setting after the printer is initialized or
-    the Clear Printer (0x10) command is received
-    """
-
     def use_slip_only(self):
+        """Selects the Slip Station for all functions.
+
+        The receipt station is the default setting after the printer
+        is initialized or the Clear Printer (0x10) command is received
+        """
         self._raw(SLIP_SELECT)
 
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -34,7 +34,7 @@ from .constants import (
     SHEET_SLIP_MODE,
     SLIP_PRINT_AND_EJECT,
     SLIP_SELECT,
-    SLIP_EJECT
+    SLIP_EJECT,
 )
 from .constants import (
     QR_MODEL_1,
@@ -1022,10 +1022,11 @@ class Escpos(object):
     Print to the thermal printer by default (ROLL) or
     print to the slip dot matrix printer if supported (SLIP)
     """
-    def target(self, type='ROLL'):
-        if type.upper() == 'ROLL':
+
+    def target(self, type="ROLL"):
+        if type.upper() == "ROLL":
             self._raw(SHEET_ROLL_MODE)
-        elif type.upper() == 'SLIP':
+        elif type.upper() == "SLIP":
             self._raw(SHEET_SLIP_MODE)
         else:
             raise ValueError("Unsupported target")
@@ -1033,6 +1034,7 @@ class Escpos(object):
     """
     Eject the slip/cheque
     """
+
     def eject_slip(self):
         self._raw(SLIP_EJECT)
 
@@ -1041,6 +1043,7 @@ class Escpos(object):
     reverses the slip out the front of the printer far enough to be accessible to the operator.
     The impact station opens the platen in all cases.
     """
+
     def print_and_eject_slip(self):
         self._raw(SLIP_PRINT_AND_EJECT)
 
@@ -1049,6 +1052,7 @@ class Escpos(object):
     The receipt station is the default setting after the printer is initialized or
     the Clear Printer (0x10) command is received
     """
+
     def use_slip_only(self):
         self._raw(SLIP_SELECT)
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -30,6 +30,11 @@ from .constants import (
     QR_ECLEVEL_M,
     QR_ECLEVEL_H,
     QR_ECLEVEL_Q,
+    SHEET_ROLL_MODE,
+    SHEET_SLIP_MODE,
+    SLIP_PRINT_AND_EJECT,
+    SLIP_SELECT,
+    SLIP_EJECT
 )
 from .constants import (
     QR_MODEL_1,
@@ -1014,6 +1019,42 @@ class Escpos(object):
             return 1
         if status[0] & RT_MASK_PAPER == RT_MASK_PAPER:
             return 2
+
+    """
+    Select where to print to
+
+    Print to the thermal printer by default (ROLL) or
+    print to the slip dot matrix printer if supported (SLIP)
+    """
+    def target(self, type='ROLL'):
+        if type.upper() == 'ROLL':
+            self._raw(SHEET_ROLL_MODE)
+        elif type.upper() == 'SLIP':
+            self._raw(SHEET_SLIP_MODE)
+        else:
+            raise ValueError("Unsupported target")
+
+    """
+    Eject the slip/cheque
+    """
+    def eject_slip(self):
+        self._raw(SLIP_EJECT)
+
+    """
+    Prints data from the buffer to the slip station and if the paper sensor is covered,
+    reverses the slip out the front of the printer far enough to be accessible to the operator.
+    The impact station opens the platen in all cases.
+    """
+    def print_and_eject_slip(self):
+        self._raw(SLIP_PRINT_AND_EJECT)
+
+    """
+    Selects the Slip Station for all functions.
+    The receipt station is the default setting after the printer is initialized or
+    the Clear Printer (0x10) command is received
+    """
+    def use_slip_only(self):
+        self._raw(SLIP_SELECT)
 
 
 class EscposIO(object):


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices: NCR 7167 (waiting to have one available to test)
- [ ] My contribution is ready to be merged as is

----------

### Description
This PR add supports for printers that have both thermal printing module and a second dot matrix printer (usually for cheque, billing documents, carbon copy, etc...)

The same usual ESC/POS instructions are used to print to both printers, only some specific commands are also available for the slip printer as it works differently.

I am just not sure of what is the correct naming for the new function, if someone can take a look (I was not sure it if was better to prefix them with `slip_` for example or just more proper english `action_object_etc...` like how I done it ?

I did not test the feature yet, I should have a printer available for testing end of the week. (NCR 7167), the ECSPOS commands I used are the ones from the NCR documentation, it looks like it's standard ESCPOS so it should work fine on others models like EPSON, etc...)

https://kedare-public.s3-website.fr-par.scw.cloud/docs/NCR-ESCPOS.pdf
