### PR TITLE
Remove sleep when quering status. Fixes #407

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -1174,7 +1174,6 @@ class Escpos(object):
         :rtype: array(integer)
         """
         self._raw(mode)
-        time.sleep(0.1)
         status = self._read()
         return status
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -1174,7 +1174,7 @@ class Escpos(object):
         :rtype: array(integer)
         """
         self._raw(mode)
-        time.sleep(1)
+        time.sleep(0.1)
         status = self._read()
         return status
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -14,7 +14,6 @@ This module contains the abstract base class :py:class:`Escpos`.
 import qrcode
 import textwrap
 import six
-import time
 from re import match as re_match
 
 import barcode


### PR DESCRIPTION
### Description
Remove the unneeded `sleep()` that stalls the printer status query.
Fixes #407.


### Tested with
_If applicable, please describe with which device you have tested._