### PR TITLE
fix typo in lp connector

### DIFF
--- a/src/escpos/printer/lp.py
+++ b/src/escpos/printer/lp.py
@@ -19,7 +19,7 @@ from ..escpos import Escpos
 def is_usable() -> bool:
     """Indicate whether this component can be used due to dependencies."""
     usable = False
-    if sys.platform.startswith("win"):
+    if not sys.platform.startswith("win"):
         usable = True
     return usable
 


### PR DESCRIPTION
### Description

Typo at the function `is_usable()` of the module `lp` :
platform has `not` to be windows

### Tested with
_If applicable, please describe with which device you have tested._