### PR TITLE
Fix import issues with qrcode in sphinx 7.2

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,6 +47,9 @@ extensions = [
     "sphinxcontrib.spelling",
 ]
 
+# mock the following modules for autodoc
+autodoc_mock_imports = ["qrcode"]
+
 # supress warnings for external images
 suppress_warnings = [
     "image.nonlocal_uri",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ root = os.path.relpath(os.path.join(os.path.dirname(__file__), ".."))
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,4 +11,5 @@ python-barcode>=0.11.0,<1
 importlib-metadata
 importlib_resources
 sphinxcontrib.datatemplates
+sphinx-autodoc-typehints
 pycups

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ setenv = PY_IGNORE_IMPORTMISMATCH=1
 [testenv:docs]
 basepython = python
 changedir = doc
-deps = sphinx>=3.0.0,<7
+deps = sphinx>=3.0.0,<7.2
        setuptools_scm
        python-barcode
        sphinxcontrib-spelling>=7.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -30,11 +30,12 @@ setenv = PY_IGNORE_IMPORTMISMATCH=1
 [testenv:docs]
 basepython = python
 changedir = doc
-deps = sphinx>=3.0.0
+deps = sphinx>=3.0.0,<7
        setuptools_scm
        python-barcode
        sphinxcontrib-spelling>=7.2.0
        sphinxcontrib.datatemplates
+       sphinx-autodoc-typehints
        sphinx_rtd_theme
        pycups
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ setenv = PY_IGNORE_IMPORTMISMATCH=1
 [testenv:docs]
 basepython = python
 changedir = doc
-deps = sphinx>=3.0.0,<7.2
+deps = sphinx>=7.2.3
        setuptools_scm
        python-barcode
        sphinxcontrib-spelling>=7.2.0


### PR DESCRIPTION
This prevents issues with sphinx 7.2

### Description
Fixes a circular import that has been introduced with sphinx 7.2 and qrcode.

### Tested with
_If applicable, please describe with which device you have tested._