### PR TITLE
[FIX] typing_extensions is missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -e .
+typing_extensions


### PR DESCRIPTION
With this commit the module doesn't work : https://github.com/python-escpos/python-escpos/commit/44444f3c5100080c9a635112e592733be402b2c0

### Description


### Tested with
_If applicable, please describe with which device you have tested._