### PR TITLE
isort imports on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,7 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "python.formatting.provider": "black",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
 }


### PR DESCRIPTION
### Description
This tells vscode to sort the imports on save with isort.

### Tested with
VS Code