### PR TITLE
Magic encoder: fix codepage usage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ contributors
 - list
 - contributors
 
-- scott-r in `#570 <https://github.com/python-escpos/python-escpos/issues/570>`_
+-  Scott Rotondo  in `#570 <https://github.com/python-escpos/python-escpos/issues/570>`_
 
 2023-05-11 - Version 3.0a9 - "Pride Comes Before A Fall"
 --------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,10 +12,14 @@ changes
 - has
 - changed
 
+- fix the encoding search so that lower encodings are found first
+
 contributors
 ^^^^^^^^^^^^
 - list
 - contributors
+
+- scott-r in [#570](https://github.com/python-escpos/python-escpos/issues/570)
 
 2023-05-11 - Version 3.0a9 - "Pride Comes Before A Fall"
 --------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ contributors
 - list
 - contributors
 
-- scott-r in [#570](https://github.com/python-escpos/python-escpos/issues/570)
+- scott-r in `#570 <https://github.com/python-escpos/python-escpos/issues/570>`_
 
 2023-05-11 - Version 3.0a9 - "Pride Comes Before A Fall"
 --------------------------------------------------------

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -67,6 +67,7 @@ Heuel
 Qian
 Lehtonen
 Kanzler
+scott-r
 
 barcode
 barcodes

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -67,7 +67,7 @@ Heuel
 Qian
 Lehtonen
 Kanzler
-scott-r
+Rotondo
 
 barcode
 barcodes

--- a/src/escpos/magicencode.py
+++ b/src/escpos/magicencode.py
@@ -155,7 +155,8 @@ class Encoder(object):
 
     def __encoding_sort_func(self, item):
         key, index = item
-        return (key in self.used_encodings, index)
+        used = key in self.used_encodings
+        return (not used, index)
 
     def find_suitable_encoding(self, char):
         """Search in a specific order for a suitable encoding.

--- a/test/test_magicencode.py
+++ b/test/test_magicencode.py
@@ -32,6 +32,13 @@ class TestEncoder:
         assert not Encoder({"CP437": 1}).find_suitable_encoding("€")
         assert Encoder({"CP858": 1}).find_suitable_encoding("€") == "CP858"
 
+    def test_find_suitable_encoding_unnecessary_codepage_swap(self):
+        enc = Encoder({"CP857": 1, "CP437": 2, "CP1252": 3, "CP852": 4, "CP858": 5})
+        # desired behavior would be that the encoder always stays in the lower
+        # available codepages if possible
+        for character in ("Á", "É", "Í", "Ó", "Ú"):
+            assert enc.find_suitable_encoding(character) == "CP857"
+
     def test_get_encoding(self):
         with pytest.raises(ValueError):
             Encoder({}).get_encoding_name("latin1")


### PR DESCRIPTION
### Description
It is convention and intent of the driver
to use the lower codepages first.
This has been swapped as pointed out in
#570.


### Tested with
Tested with unit tests