### PR TITLE
import TypedDict from typing, not from extensions

### DIFF
--- a/src/escpos/types/__init__.py
+++ b/src/escpos/types/__init__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 """Custom types."""
 
-from typing import Dict
-
-from typing_extensions import TypedDict
+from typing import Dict, TypedDict
 
 
 class ConstTxtStyleClass(TypedDict):


### PR DESCRIPTION
### Description
TypedDict is in the supported python versions
available in typing. Therefore an import from
potentially uninstalled typing_extensions is
not necessary.

fixes #560

### Tested with
_If applicable, please describe with which device you have tested._