### PR TITLE
Restore types-pywin32

### DIFF
--- a/src/escpos/printer/win32raw.py
+++ b/src/escpos/printer/win32raw.py
@@ -148,7 +148,7 @@ class Win32Raw(Escpos):
         win32print.ClosePrinter(self._device)
         self._device = False
 
-    def _raw(self, msg):
+    def _raw(self, msg) -> None:
         """Print any command sent in raw format.
 
         :param msg: arbitrary code to be printed

--- a/src/escpos/printer/win32raw.py
+++ b/src/escpos/printer/win32raw.py
@@ -10,7 +10,7 @@
 
 import functools
 import logging
-from typing import Literal, Optional, Type, Union
+from typing import Any, Literal, Optional, Union
 
 from ..escpos import Escpos
 from ..exceptions import DeviceNotFoundError
@@ -20,9 +20,11 @@ _DEP_WIN32PRINT = False
 
 
 try:
+    import pywintypes
     import win32print
 
     _DEP_WIN32PRINT = True
+    PyPrinterHANDLE: Any = win32print.OpenPrinter
 except ImportError:
     pass
 
@@ -83,7 +85,7 @@ class Win32Raw(Escpos):
         self._device: Union[
             Literal[False],
             Literal[None],
-            Type[win32print.OpenPrinter],
+            "PyPrinterHANDLE",
         ] = False
 
     @property
@@ -115,15 +117,15 @@ class Win32Raw(Escpos):
             self.printer_name = self.printer_name or win32print.GetDefaultPrinter()
             assert self.printer_name in self.printers, "Incorrect printer name"
             # Open device
-            self.device: Optional[
-                Type[win32print.OpenPrinter]
-            ] = win32print.OpenPrinter(self.printer_name)
+            self.device: Optional["PyPrinterHANDLE"] = win32print.OpenPrinter(
+                self.printer_name
+            )
             if self.device:
                 self.current_job = win32print.StartDocPrinter(
-                    self.device, 1, (job_name, None, "RAW")
+                    self.device, 1, (job_name, "", "RAW")
                 )
                 win32print.StartPagePrinter(self.device)
-        except AssertionError as e:
+        except (AssertionError, pywintypes.error) as e:
             # Raise exception or log error and cancel
             self.device = None
             if raise_not_found:

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ deps = mypy
        types-appdirs
        types-Pillow
        types-pyserial
+       types-pywin32>=306.0.0.6
        hypothesis>=6.83
        jaconv
 commands = mypy src test


### PR DESCRIPTION
### Description
As mentioned in https://github.com/python-escpos/python-escpos/pull/554#issuecomment-1759762685 the types-pywin32 package was causing False positives  to the type checking.
I reported this issue to the python/typeshed proyect https://github.com/python/typeshed/issues/10891 where it was fixed and finally yesterday the types-pywin32 pypi repo was updated to v.306.0.0.6 that includes this fix.

We can restore the usage of the types-pywin32 dependency to enhance the type checking of the Win32Raw printer.


### Tested with
_If applicable, please describe with which device you have tested._