### PR TITLE
argparse is an part of the python core

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ install_requires =
     six
     appdirs
     PyYAML
-    argparse
     argcomplete
     importlib_resources
 setup_requires = setuptools_scm


### PR DESCRIPTION
### Description
argparse is not needed as an requirement, because it will be an python core part.

### Tested with
_If applicable, please describe with which device you have tested._