### PR TITLE
Add sleep in sending fragments

### DIFF
--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -91,6 +91,7 @@ docstrings
 ean
 Ean
 encodable
+Errno
 fff
 fullimage
 io
@@ -124,6 +125,7 @@ Todo
 traceback
 udev
 usb
+USBTimeoutError
 usec
 virtualenvs
 whitespaces

--- a/doc/user/usage.rst
+++ b/doc/user/usage.rst
@@ -213,6 +213,14 @@ If something is wrong, an ``CharCodeError`` will be raised.
 After you have manually set the codepage the printer won't change it anymore.
 You can revert to normal behavior by setting charcode to ``AUTO``.
 
+Resolving bus timeout issues during printing images
+---------------------------------------------------
+
+If an error message such as "USBTimeoutError: [Errno 110] Operation timed out" occurs,
+setting a sleep time between printing fragments can help.
+
+This can be done with the :meth:`.set_sleep_in_fragment()` method.
+
 Advanced Usage: Print from binary blob
 --------------------------------------
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import textwrap
 import warnings
+import time
 from abc import ABCMeta, abstractmethod  # abstract base class support
 from re import match as re_match
 from types import TracebackType
@@ -244,6 +245,7 @@ class Escpos(object, metaclass=ABCMeta):
                     impl=impl,
                     fragment_height=fragment_height,
                 )
+                time.sleep(0.3)
             return
 
         if impl == "bitImageRaster":

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -12,8 +12,8 @@ This module contains the abstract base class :py:class:`Escpos`.
 from __future__ import annotations
 
 import textwrap
-import warnings
 import time
+import warnings
 from abc import ABCMeta, abstractmethod  # abstract base class support
 from re import match as re_match
 from types import TracebackType


### PR DESCRIPTION
Adding sleep prevents "USBTimeoutError: [Errno 110] Operation timed out".

### Description


### Tested with
Raspberry Pi with this printer via USB
https://a.aliexpress.com/_oFusnk4