### PR TITLE
New feature: Software columns

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -107,6 +107,8 @@ SW_BARCODE_NAMES = {
     for name in barcode.PROVIDED_BARCODES
 }
 
+Alignment = Union[Literal["center", "left", "right"], str]
+
 
 class Escpos(object, metaclass=ABCMeta):
     """ESC/POS Printer object.

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -899,6 +899,26 @@ class Escpos(object, metaclass=ABCMeta):
         col_count = self.profile.get_columns(font) if columns is None else columns
         self.text(textwrap.fill(txt, col_count))
 
+    @staticmethod
+    def padding(
+        text: str,
+        width: int,
+        align: Alignment = "center",
+    ) -> str:
+        """Add fill space to meet the width.
+
+        The align parameter sets the alignment of the text in space.
+        """
+        align = align.lower()
+        if align == "center":
+            text = f"{text:^{width}}"
+        elif align == "left":
+            text = f"{text:<{width}}"
+        elif align == "right":
+            text = f"{text:>{width}}"
+
+        return text
+
     def set(
         self,
         align: Optional[str] = None,

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -919,6 +919,16 @@ class Escpos(object, metaclass=ABCMeta):
 
         return text
 
+    @staticmethod
+    def truncate(text: str, width: int, placeholder: str = ".") -> str:
+        """Truncate an string at a max width or leave it untouched.
+
+        Add a placeholder at the end of the output text if it has been truncated.
+        """
+        ph_len = len(placeholder)
+        max_len = width - ph_len
+        return f"{text[:max_len]}{placeholder}" if len(text) > width else text
+
     def set(
         self,
         align: Optional[str] = None,

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -929,6 +929,17 @@ class Escpos(object, metaclass=ABCMeta):
         max_len = width - ph_len
         return f"{text[:max_len]}{placeholder}" if len(text) > width else text
 
+    @staticmethod
+    def _repeat_last(iterable, max_iterations: int = 1000):
+        """Iterate over the items of a list repeating the last one until max_iterations."""
+        i = 0
+        while i < max_iterations:
+            try:
+                yield iterable[i]
+            except IndexError:
+                yield iterable[-1]
+            i += 1
+
     def set(
         self,
         align: Optional[str] = None,

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -940,6 +940,28 @@ class Escpos(object, metaclass=ABCMeta):
                 yield iterable[-1]
             i += 1
 
+    def _rearrange_into_cols(self, text_list: list, widths: list[int]) -> list:
+        """Wrap and convert a list of strings into an array of text columns.
+
+        Set the width of each column by passing a list of widths.
+        Wrap if possible and|or truncate strings longer than its column width.
+        Reorder the wrapped items into an array of text columns.
+        """
+        n_cols = len(text_list)
+        wrapped = [
+            textwrap.wrap(text, widths[i], break_long_words=False)
+            for i, text in enumerate(text_list)
+        ]
+        max_len = max(*[len(text_group) for text_group in wrapped])
+        text_colums = []
+        for i in range(max_len):
+            row = ["" for _ in range(n_cols)]
+            for j, item in enumerate(wrapped):
+                if i in range(len(item)):
+                    row[j] = self.truncate(item[i], widths[j])
+            text_colums.append(row)
+        return text_colums
+
     def set(
         self,
         align: Optional[str] = None,

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -973,6 +973,41 @@ class Escpos(object, metaclass=ABCMeta):
             self.padding(text, widths[i], align[i]) for i, text in enumerate(text_list)
         ]
 
+    def software_columns(
+        self,
+        text_list: list,
+        widths: Union[list[int], int],
+        align: Union[list[Alignment], Alignment],
+    ) -> None:
+        """Print a list of strings arranged horizontaly in columns.
+
+        :param text_list: list of strings, each item in the list will be printed as a column.
+
+        :param widths: width of each column by passing a list of widths,
+            or a single total width to arrange columns of the same size.
+            If the list of width items is shorter than the list of strings then
+            the last width of the list will be applied till the last string (column).
+
+        :param align: alignment of the text into each column by passing a list of alignments,
+            or a single alignment for all the columns.
+            If the list of alignment items is shorter than the list of strings then
+            the last alignment of the list will be applied till the last string (column).
+        """
+        n_cols = len(text_list)
+
+        if isinstance(widths, int):
+            widths = [round(widths / n_cols)]
+        widths = list(self._repeat_last(widths, max_iterations=n_cols))
+
+        if isinstance(align, str):
+            align = [align]
+        align = list(self._repeat_last(align, max_iterations=n_cols))
+
+        columns = self._rearrange_into_cols(text_list, widths)
+        for row in columns:
+            padded = self._add_padding_into_cols(row, widths, align)
+            self.textln("".join(padded))
+
     def set(
         self,
         align: Optional[str] = None,

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -979,7 +979,7 @@ class Escpos(object, metaclass=ABCMeta):
         widths: Union[list[int], int],
         align: Union[list[Alignment], Alignment],
     ) -> None:
-        """Print a list of strings arranged horizontaly in columns.
+        """Print a list of strings arranged horizontally in columns.
 
         :param text_list: list of strings, each item in the list will be printed as a column.
 

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -962,6 +962,17 @@ class Escpos(object, metaclass=ABCMeta):
             text_colums.append(row)
         return text_colums
 
+    def _add_padding_into_cols(
+        self,
+        text_list: list[str],
+        widths: list[int],
+        align: list[Alignment],
+    ) -> list:
+        """Add padding, width and alignment into the items of a list of strings."""
+        return [
+            self.padding(text, widths[i], align[i]) for i, text in enumerate(text_list)
+        ]
+
     def set(
         self,
         align: Optional[str] = None,

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -107,8 +107,6 @@ SW_BARCODE_NAMES = {
     for name in barcode.PROVIDED_BARCODES
 }
 
-Alignment = Union[Literal["center", "left", "right"], str]
-
 
 class Escpos(object, metaclass=ABCMeta):
     """ESC/POS Printer object.

--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -900,7 +900,7 @@ class Escpos(object, metaclass=ABCMeta):
         self.text(textwrap.fill(txt, col_count))
 
     @staticmethod
-    def padding(
+    def _padding(
         text: str,
         width: int,
         align: Alignment = "center",
@@ -920,7 +920,7 @@ class Escpos(object, metaclass=ABCMeta):
         return text
 
     @staticmethod
-    def truncate(text: str, width: int, placeholder: str = ".") -> str:
+    def _truncate(text: str, width: int, placeholder: str = ".") -> str:
         """Truncate an string at a max width or leave it untouched.
 
         Add a placeholder at the end of the output text if it has been truncated.
@@ -958,7 +958,7 @@ class Escpos(object, metaclass=ABCMeta):
             row = ["" for _ in range(n_cols)]
             for j, item in enumerate(wrapped):
                 if i in range(len(item)):
-                    row[j] = self.truncate(item[i], widths[j])
+                    row[j] = self._truncate(item[i], widths[j])
             text_colums.append(row)
         return text_colums
 
@@ -970,7 +970,7 @@ class Escpos(object, metaclass=ABCMeta):
     ) -> list:
         """Add padding, width and alignment into the items of a list of strings."""
         return [
-            self.padding(text, widths[i], align[i]) for i, text in enumerate(text_list)
+            self._padding(text, widths[i], align[i]) for i, text in enumerate(text_list)
         ]
 
     def software_columns(


### PR DESCRIPTION
### Description

This implements `software_columns()` as a new feature to help in the tricky task of printing texts in columns or aligning multiple texts in different alignments within the same line.

The method receives a list of strings and formats them as horizontal columns by adding spaces between each element. If some text is too long it is wrapped to the column width by adding new lines and even truncating words that are too long by adding a placeholder.
It is also possible to set the width and the text alignment of each column independently. The method is flexible enough to repeat the last width and/or alignment till the last element if there are more text elements than column widths or alignments.
- Example 1: The user passes a list of 4 text items and wants the first one to be 20 characters wide and 10 for the rest, then he/she only needs to pass the value `widths=[20, 10]` to the method so it will be expanded to '[20, 10, 10, 10]`.
- Example 2: The user passes a list of 4 text items and wants all them to be the same size along a maximum total width of 40 characters, then he/she simply passes the value `widths=40` so it will be expanded to `[10, 10, 10, 10]`.

This is also true for the alignment parameter:
- On a list of 4 text items `align=['left', 'center', 'right']` would expand to `['left', 'center', 'right', 'right']`. Alternatively a single value `align='center'` would expand to `['center', 'center', 'center', 'center']`.

At the moment, the user is responsible for not exceeding the width of the paper when passing the list of `widths` parameter, but this behavior could be modified by adding a check, an exception or whatever.

As always all suggestions, corrections, etc. are very welcome.

Closes #27
Closes #635

### Tested with
- Epson TM-U210