### PR TITLE
New feature: Software columns - Part 2: CLI

### DIFF
--- a/src/escpos/cli.py
+++ b/src/escpos/cli.py
@@ -20,8 +20,9 @@ except ImportError:
     pass  # noqa
 import sys
 
-from . import config, escpos, version
+from . import config, escpos
 from . import printer as escpos_printer_module
+from . import version
 
 
 # Must be defined before it's used in DEMO_FUNCTIONS

--- a/src/escpos/cli.py
+++ b/src/escpos/cli.py
@@ -20,9 +20,8 @@ except ImportError:
     pass  # noqa
 import sys
 
-from . import config, escpos
+from . import config, escpos, version
 from . import printer as escpos_printer_module
-from . import version
 
 
 # Must be defined before it's used in DEMO_FUNCTIONS
@@ -206,6 +205,38 @@ ESCPOS_COMMANDS: List[Dict[str, Any]] = [
                 "option_strings": ("--columns",),
                 "help": "Number of columns",
                 "type": int,
+            },
+        ],
+    },
+    {
+        "parser": {
+            "name": "software_columns",
+            "help": "Print a list of texts arranged into columns",
+        },
+        "defaults": {
+            "func": "software_columns",
+        },
+        "arguments": [
+            {
+                "option_strings": ("--text_list",),
+                "help": "list of texts to print",
+                "nargs": "+",
+                "type": str,
+                "required": True,
+            },
+            {
+                "option_strings": ("--widths",),
+                "help": "list of column widths",
+                "nargs": "+",
+                "type": int,
+                "required": True,
+            },
+            {
+                "option_strings": ("--align",),
+                "help": "list of column alignments",
+                "nargs": "+",
+                "type": str,
+                "required": True,
             },
         ],
     },


### PR DESCRIPTION
### Description
This is part 2 of the series on implementing [software columns](https://github.com/python-escpos/python-escpos/pull/645).

This enables the CLI to accept the new `software_columns` sub-command with the arguments `--text_list`, `--widths` and `--align` corresponding to the same method name and params in the API.

### Tested with
Epson TM-U210