### PR TITLE
Make logging.basicConfig conditional

### DIFF
--- a/src/escpos/capabilities.py
+++ b/src/escpos/capabilities.py
@@ -13,9 +13,10 @@ from typing import Any, Dict, Optional, Type
 import importlib_resources
 import yaml
 
-logging.basicConfig()
-logger = logging.getLogger(__name__)
+if environ.get("ESCPOS_CAPABILITIES_DEBUG", 0):
+    logging.basicConfig()
 
+logger = logging.getLogger(__name__)
 pickle_dir = environ.get("ESCPOS_CAPABILITIES_PICKLE_DIR", mkdtemp())
 pickle_path = path.join(pickle_dir, f"{platform.python_version()}.capabilities.pickle")
 # get a temporary file from importlib_resources if no file is specified in env


### PR DESCRIPTION
Hi there, thank you so much for this library, I'm having a lot of fun with it!

### Description

I wrote a wrapper script using this library in which I'm using the `logging` module, and I'm noticing that all my log messages are duplicated. I found [this comment](https://github.com/python-escpos/python-escpos/issues/559#issuecomment-2560352955) in issue #559 which mentions the same thing and identifies the root cause to be the `logging.basicConfig` call in `capabilities.py`. So this PR places that call behind an environment variable, so it can still be enabled for debugging but is no longer enabled by default. I also found [this section of the Python docs](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) describing logging from a library, which seems to correspond with this change.

### Tested with

Tested with my wrapper script and this branch. With the change I made the log messages are no longer duplicated.

Thanks in advance for taking a look!