### PR TITLE
Fix wrong font choices in cli's set params. Fixes #653

### DIFF
--- a/src/escpos/cli.py
+++ b/src/escpos/cli.py
@@ -373,7 +373,7 @@ ESCPOS_COMMANDS: List[Dict[str, Any]] = [
             {
                 "option_strings": ("--font",),
                 "help": "Font choice",
-                "choices": ["left", "center", "right"],
+                "choices": ["A", "B"],
             },
             {
                 "option_strings": ("--text_type",),


### PR DESCRIPTION
### Description
This fixes #653 by replacing the wrong list of params in the cli's `set --font` method with the correct ones.

Thanks to @gloriouslyawkwardlife for reporting this issue :love_you_gesture .
