### PR TITLE
ref(package) replace appdirs with platformdirs in configuration and requirements files

### DIFF
--- a/examples/docker-flask/requirements.txt
+++ b/examples/docker-flask/requirements.txt
@@ -1,4 +1,4 @@
-appdirs==1.4.4
+platformdirs==4.3.8
 argcomplete==3.0.8
 blinker==1.6.2
 click==8.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     python-barcode>=0.15.0,<1
     setuptools
     six
-    appdirs
+    platformdirs
     PyYAML
     argcomplete
     importlib_resources

--- a/src/escpos/config.py
+++ b/src/escpos/config.py
@@ -5,7 +5,7 @@ This module contains the implementations of abstract base class :py:class:`Confi
 import os
 import pathlib
 
-import appdirs
+import platformdirs
 import yaml
 
 from . import exceptions, printer
@@ -55,7 +55,7 @@ class Config:
 
         if not config_path:
             config_path = os.path.join(
-                appdirs.user_config_dir(self._app_name), self._config_file
+                platformdirs.user_config_dir(self._app_name), self._config_file
             )
         if isinstance(config_path, pathlib.Path):
             # store string if posixpath

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -8,7 +8,7 @@
 """
 import pathlib
 
-import appdirs
+import platformdirs
 import pytest
 
 import escpos.exceptions
@@ -80,7 +80,7 @@ def test_config_load_from_appdir() -> None:
 
     # generate a dummy config
     config_file = (
-        pathlib.Path(appdirs.user_config_dir(config.Config._app_name))
+        pathlib.Path(platformdirs.user_config_dir(config.Config._app_name))
         / config.Config._config_file
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,6 @@ deps = mypy
        types-six
        types-mock
        types-PyYAML
-       # types-appdirs
        types-Pillow
        types-pyserial
        types-pywin32>=306.0.0.6

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps = mypy
        types-six
        types-mock
        types-PyYAML
-       types-appdirs
+       # types-appdirs
        types-Pillow
        types-pyserial
        types-pywin32>=306.0.0.6


### PR DESCRIPTION
Fixes: #696

### Description

Replace `appdirs` with `platformdirs` and adjust related fields.

### Tested with

I haven't tested with any device.
