### PR TITLE
ref(coverage-config): migrate coverage config from `.coveragerc` to `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-branch = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ module = ["pytest",
           "win32print"
          ]
 ignore_missing_imports = true
+
+[tool.coverage.run]
+branch = true


### PR DESCRIPTION
Related to #698 

### Description

Move coverage configuration to `pyproject.toml` file.
