### PR TITLE
Improve and extend the _read() method availability for its users and related methods. Part 4: Implement _read() in Dummy()

### DIFF
--- a/src/escpos/printer/dummy.py
+++ b/src/escpos/printer/dummy.py
@@ -52,6 +52,12 @@ class Dummy(Escpos):
         """
         self._output_list.append(msg)
 
+    def _read(self) -> bytes:
+        """Read the last byte of data and return it to the caller."""
+        if not self._output_list:
+            return b""
+        return self._output_list[-1]
+
     @property
     def output(self) -> bytes:
         """Get the data that was sent to this printer."""

--- a/src/escpos/printer/dummy.py
+++ b/src/escpos/printer/dummy.py
@@ -56,7 +56,7 @@ class Dummy(Escpos):
         """Read the last byte of data and return it to the caller."""
         if not self._output_list:
             return b""
-        return self._output_list[-1]
+        return bytes([self._output_list[-1][-1]])
 
     @property
     def output(self) -> bytes:

--- a/test/test_functions/test_function_dummy_clear.py
+++ b/test/test_functions/test_function_dummy_clear.py
@@ -1,8 +1,0 @@
-from escpos.printer import Dummy
-
-
-def test_printer_dummy_clear() -> None:
-    printer = Dummy()
-    printer.text("Hello")
-    printer.clear()
-    assert printer.output == b""

--- a/test/test_printers/test_printer_dummy.py
+++ b/test/test_printers/test_printer_dummy.py
@@ -23,7 +23,7 @@ def test_clear(driver) -> None:
 def test_read_no_output(driver) -> None:
     """
     GIVEN a dummy printer object with no output data
-    WHEN reading the last byte of data 
+    WHEN reading the last byte of data
     THEN check the return value is the expected
     """
     driver.clear()

--- a/test/test_printers/test_printer_dummy.py
+++ b/test/test_printers/test_printer_dummy.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+#  -*- coding: utf-8 -*-
+"""tests for the Dummy printer
+
+:author: Benito López and the python-escpos developers
+:organization: `python-escpos <https://github.com/python-escpos>`_
+:copyright: Copyright (c) 2025 `python-escpos <https://github.com/python-escpos>`_
+:license: MIT
+"""
+
+
+def test_clear(driver) -> None:
+    """
+    GIVEN a dummy printer object
+    WHEN clear method is called
+    THEN check the return value is the expected
+    """
+    driver.text("Hello")
+    driver.clear()
+    assert driver.output == b""
+
+
+def test_read_no_output(driver) -> None:
+    """
+    GIVEN a dummy printer object with no output data
+    WHEN reading the last byte of data 
+    THEN check the return value is the expected
+    """
+    driver.clear()
+    assert driver._read() == b""
+
+
+def test_read(driver) -> None:
+    """
+    GIVEN a dummy printer object
+    WHEN reading the last byte of data
+    THEN check the return value is the expected
+    """
+    driver._raw(b"\x10\x04\x01")  # RT_STATUS_ONLINE
+    assert driver._read() == b"\x01"
+    driver._raw(b"\x12")  # Simulate an 'is online' response
+    assert driver._read() == b"\x12"


### PR DESCRIPTION
### Description
This is part 4 of the series to improve and extend the availability of the _read() method.

#### Part 1: #709 

#### Part 2: #711

#### Part 3: #712

#### Part 4: Add the `_read()` method to the `Dummy()` connector:
This adds an initial implementation of the `_read()` method to the `Dummy()` connector that, until now, was lacking this feature and was raising a `NotImplementedError` exception.

Note that this is only useful for testing as no real response can be obtained from any printer by the Dummy connector.

Features:
- Implement the _read() method on the Dummy() class.
- Add and group the new tests plus the existing one into a new test file located at test/test_printers/test_printer_dummy.py.

~~Tests will be added in a later PR.~~

### Tested with
Dummy printer