### PR TITLE
docs: clarify python-escpos package name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 changes
 ^^^^^^^
 
+- document that the package should be installed as ``python-escpos``, not the
+  unrelated ``escpos`` package
 
 contributors
 ^^^^^^^^^^^^

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -21,6 +21,16 @@ always install from PyPi.
 If you use the ``--pre`` parameter for ``pip``, you will get the latest
 pre-release.
 
+.. note::
+
+   The PyPI package name is ``python-escpos``. The unrelated and discontinued
+   package named ``escpos`` uses the same ``escpos`` import namespace and can
+   shadow python-escpos if both are installed in the same environment. If an
+   import such as ``from escpos.printer import Usb`` fails with
+   ``ImportError: cannot import name 'DeviceNotFoundError' from
+   'escpos.exceptions'``, remove the ``escpos`` package and reinstall
+   ``python-escpos`` in a clean environment.
+
 The following installation options exist:
 
  * `all`: install all packages available for this platform


### PR DESCRIPTION
### Description

Adds an installation note that the PyPI package name is `python-escpos`, not the unrelated discontinued `escpos` package. The note explains that installing both can shadow the shared `escpos` import namespace and produce import errors like the `DeviceNotFoundError` case reported in #629.

Also adds a changelog entry for the documentation update.

Helps #629.

### Tested with

Not run locally; documentation-only change.

Validation:

* `git diff --check`
* `git show --check --stat --oneline HEAD`
* `rg -n "DeviceNotFoundError|python-escpos|unrelated.*escpos|package named ``escpos``|document that the package" CHANGELOG.rst doc/user/installation.rst`
