### PR TITLE
tox: pass the args to pytest to select tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ deps = [
   "python-barcode>=0.16.0,<1",
 ]
 extras = ["all"]
-commands = [["pytest"]]
+commands = [["pytest", { replace = "posargs", extend = true }]]
 passenv = [
   "ESCPOS_CAPABILITIES_PICKLE_DIR",
   "ESCPOS_CAPABILITIES_FILE",


### PR DESCRIPTION
The following invocation:
    
     tox --conf pyproject.toml run -- -k magicencode
    
will run only magicencode tests